### PR TITLE
fix(governance): operator/rule-derived Deny is terminal — never capability-token-flippable (#3111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security (capability-token grant can NEVER override an operator Deny — #3111, GA-blocker)
+
+- **#3111 (security / operator-permission bypass, GA-blocker) — a
+  capability token could flip an EXPLICIT operator/rule-derived `Deny` to
+  `Allow`.** `apply_capability_grant` (the write-gate joiner behind
+  `apply_at_gate` / `enforce_governance`, on BOTH the sqlite and postgres
+  gates) treated a `Deny` base as flippable alongside `Ask`: a holder of a
+  valid delegated token whose caveat chain + issuer ceiling covered the
+  in-flight `(action, namespace)` tuple flipped the base to `Allow`. But
+  `verify` checks only the token's version / issuer / HMAC chain / caveats /
+  issuer ceiling — it NEVER consults the permission rules that produced the
+  `Deny` — so a delegated (possibly attenuated, AI-held) token silently
+  bypassed a standing operator refusal (e.g. a `[permissions]` "no writes to
+  `secrets/*`" rule, or an owner-policy namespace Deny). This violates the
+  mission-critical security pillar that operator permission rules can NEVER
+  be bypassed by AI agents. **Ruled FREEZE 20-0 (unanimous)** by the 3×7
+  adversarial GA panel. The fix makes an operator/rule-derived `Deny`
+  **terminal**: `apply_capability_grant` now short-circuits every non-`Ask`
+  base (a `Deny` or a `Modify`) to `GrantOutcome::NoOp` **before** `verify`
+  runs, so no code path from a `Deny` base can reach `Allow` — the property
+  is structural, not conditional. Only an `Ask`/`Pending` (a pending human
+  court) base remains liftable, which is the intended delegation model
+  (delegation-over-deny is not). Zero product-API change for compliant
+  flows; a token presented against a `Deny` is now inert (no grant, and no
+  new audit bytes). Live regressions cover the pure joiner, the wired sqlite
+  gate, the sqlite/postgres parity matrix, and the forensic-audit surface.
+  Files: `src/governance/capability.rs` (the joiner + its contract docs),
+  `tests/g10_capability_tokens.rs`, `src/config.rs` (the R9 default-on
+  additive test), `docs/CLI_REFERENCE.md`,
+  `docs/spec/TRACT-L1-CLAIM-CONTRACT.md`.
+
 ### Fixed (cross-backend parity — search/list/recall `since`/`until` compared by INSTANT on sqlite #3279)
 
 - **#3279 (correctness / backend divergence, GA-blocker) — the sqlite

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -81,7 +81,7 @@ never downgrades.
 | `--entity-id` | string | — | QW-2 persona binding; required with `--kind persona`. |
 | `--sign` | bool | `false` | **#626 Layer-3** — sign the write with the resolved agent's local Ed25519 keypair so the stored row is *attested* (`attest_level = "agent_attested"`) rather than merely *claimed*. Requires a `<agent_id>.priv` under the key directory (`AI_MEMORY_KEY_DIR` or the platform default) and a matching bound public key (`ai-memory agents bind-key`). Without `--sign`, the CLI `store` surface is **permissive by default** (operator-as-actor, #1985) — an unsigned write lands *claimed*, not rejected. It is rejected only when the operator has forced strict enforcement via `AI_MEMORY_REQUIRE_AGENT_ATTESTATION=1` (or `=true`); see the env-var table above for the full surface-scoped default. |
 | `--write-v2` | path | — | v1.0.0 crypto-core (#1942/#1941) — path to a JSON `write_v2` presentation envelope (certified sub-key signature over the v2 CBOR-array pre-image). Takes precedence over `--sign`; on success stamps `agent_attested`. An invalid/forged envelope is REJECTED. See `docs/attestation.md` §"v2". |
-| `--capability` | string | — | v0.9.0 G10.1 (#1827) — macaroon capability token (`cap1:...`) that may flip a governance Deny/Pending to Allow within its caveats. Inert unless `[capabilities].enabled`. |
+| `--capability` | string | — | v0.9.0 G10.1 (#1827) — macaroon capability token (`cap1:...`) that may lift a governance `Pending` (human court) to Allow within its caveats. An explicit operator/rule-derived `Deny` is terminal and is never token-flippable (#3111). Inert unless `[capabilities].enabled`. |
 
 ```bash
 ai-memory store --title "Q2 roadmap" \
@@ -1313,8 +1313,10 @@ this document claims to track. Each maps 1:1 to a `Command` variant in
 
 Stateless bearer grants consumed by the governance gates. A valid token
 whose caveat chain and issuer ceiling cover the in-flight
-`(action, namespace)` flips an otherwise-`Deny`/`Ask` coarse-gate
-decision to `Allow` — **attenuation-only widening**, never escalation.
+`(action, namespace)` lifts an otherwise-`Ask`/`Pending` (human-court)
+coarse-gate decision to `Allow` — **attenuation-only widening**, never
+escalation. An explicit operator/rule-derived `Deny` is terminal and is
+never token-flippable (#3111).
 Tokens are presented via the MCP `capability` param, the
 `X-AI-Memory-Capability` HTTP header, or `--capability` / `--capability-file`
 on governed CLI verbs (`store`, `delete`, `promote`). A caller that presents

--- a/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
+++ b/docs/spec/TRACT-L1-CLAIM-CONTRACT.md
@@ -598,8 +598,8 @@ The G10.1 capability primitive (`Caveat::NamespacePrefix`, `op_level_of("Reflect
 → OpLevel::Read`) is the **intended** bridge, but recall does not consume it, and
 wiring it is neither a clean reuse nor fully specified:
 
-- **Not a reuse.** `apply_capability_grant` is a write-gate joiner that only flips
-  `Deny`/`Ask`→`Allow`; recall is Allow-by-default, with no `GovernedAction::Read`
+- **Not a reuse.** `apply_capability_grant` is a write-gate joiner that only lifts
+  `Ask`→`Allow` (a `Deny` is terminal, #3111); recall is Allow-by-default, with no `GovernedAction::Read`
   / `policy.core.read` and no gate call. A read-bridge must first *invent* a
   base-`Deny`-on-cross-namespace posture (a security-posture inversion), then
   thread a token through the recall chain (both SAL backends + MCP/HTTP/CLI

--- a/src/config.rs
+++ b/src/config.rs
@@ -11679,11 +11679,15 @@ legacy_scoring = false
     }
 
     #[test]
-    fn r9_default_on_is_additive_owner_token_widens_but_adds_no_denial() {
-        // #1960 R9 — with capabilities ON and the zero-config owner enrolled:
-        // (1) a valid owner token WIDENS a Deny → Allow (attenuation grant);
+    fn r9_default_on_is_additive_deny_terminal_pending_widens_adds_no_denial() {
+        // #1960 R9 + #3111 — with capabilities ON and the zero-config owner
+        // enrolled:
+        // (1) a valid owner token does NOT widen an operator/rule-derived
+        //     Deny — the Deny is TERMINAL (#3111): base unchanged, NoOp;
         // (2) a capability-LESS caller's Deny is UNCHANGED (zero new denial);
-        // (3) an owner token attenuated to Read cannot widen a Write.
+        // (3) a valid owner token WIDENS a Pending (human court) → Allow —
+        //     the legitimate delegated power the feature still provides;
+        // (4) an owner token attenuated to Read cannot cover a Write Pending.
         use crate::governance::capability as cap;
         use crate::models::{GovernanceDecision, GovernanceLevel, GovernedAction};
         let tmp = tempfile::tempdir().unwrap();
@@ -11728,22 +11732,30 @@ legacy_scoring = false
                 "nope",
             ))
         };
+        let pending = || GovernanceDecision::Pending("court-1".to_string());
 
-        // (1) owner token widens Deny → Allow.
+        // (1) #3111 — owner token does NOT widen an operator Deny; it is
+        //     terminal (base unchanged, NoOp — the token is never consulted).
         let (d1, o1) = cap::apply_capability_grant_gov(deny(), &cfg, true, Some(&tok), &req);
-        assert_eq!(d1, GovernanceDecision::Allow);
-        assert!(matches!(o1, cap::GrantOutcome::Granted { .. }));
+        assert_eq!(d1, deny(), "operator Deny must be terminal (#3111)");
+        assert_eq!(o1, cap::GrantOutcome::NoOp);
 
         // (2) capability-LESS caller: Deny is unchanged, NoOp (no new denial).
         let (d2, o2) = cap::apply_capability_grant_gov(deny(), &cfg, true, None, &req);
         assert!(matches!(d2, GovernanceDecision::Deny(_)));
         assert_eq!(o2, cap::GrantOutcome::NoOp);
 
-        // (3) attenuated-to-Read owner token cannot cover a Write.
+        // (3) owner token WIDENS a Pending (human court) → Allow.
+        let (d3, o3) = cap::apply_capability_grant_gov(pending(), &cfg, true, Some(&tok), &req);
+        assert_eq!(d3, GovernanceDecision::Allow);
+        assert!(matches!(o3, cap::GrantOutcome::Granted { .. }));
+
+        // (4) attenuated-to-Read owner token cannot cover a Write Pending.
         let narrowed = cap::attenuate(&tok, cap::Caveat::OpCeiling(cap::OpLevel::Read)).unwrap();
-        let (d3, o3) = cap::apply_capability_grant_gov(deny(), &cfg, true, Some(&narrowed), &req);
-        assert!(matches!(d3, GovernanceDecision::Deny(_)));
-        assert!(matches!(o3, cap::GrantOutcome::Rejected(_)));
+        let (d4, o4) =
+            cap::apply_capability_grant_gov(pending(), &cfg, true, Some(&narrowed), &req);
+        assert!(matches!(d4, GovernanceDecision::Pending(_)));
+        assert!(matches!(o4, cap::GrantOutcome::Rejected(_)));
     }
 
     #[test]

--- a/src/governance/capability.rs
+++ b/src/governance/capability.rs
@@ -90,9 +90,10 @@ pub const ENV_CAPABILITIES: &str = "AI_MEMORY_CAPABILITIES";
 ///   *actively presents* a token (an opt-in act); an invalid token is a
 ///   typed `Err(CapReject)` that REFUSES the request (fail-closed), while
 ///   an ABSENT token still yields `Ok(None)` and the bare ACL decides.
-/// - The grant path ([`apply_capability_grant`]) only ever flips a
-///   `Deny`/`Ask` base to `Allow` (attenuation-only widening); it can
-///   never turn an `Allow` into a denial.
+/// - The grant path ([`apply_capability_grant`]) only ever flips an `Ask`
+///   (pending human-court) base to `Allow` (attenuation-only widening); it
+///   never overrides an operator/rule-derived `Deny` (terminal, #3111) and
+///   never turns an `Allow` into a denial.
 ///
 /// So default-on WIDENS what a capability-bearing owner can delegate (via
 /// attenuated tokens) and adds no new denial to any pre-capability flow.
@@ -793,7 +794,7 @@ fn namespace_under(namespace: &str, prefix: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// apply_capability_grant — the Deny/Pending→Allow joiner (T4)
+// apply_capability_grant — the Ask/Pending→Allow joiner (T4)
 // ---------------------------------------------------------------------------
 
 /// The audit-relevant outcome of [`apply_capability_grant`]. The joiner is
@@ -802,11 +803,12 @@ fn namespace_under(namespace: &str, prefix: &str) -> bool {
 /// to emit via the existing `append_signed_event`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GrantOutcome {
-    /// No capability logic ran (base was Allow, feature off/not-enforce, or no
-    /// token / non-flippable base). Emit ZERO new audit bytes.
+    /// No capability logic ran (base was Allow, feature off/not-enforce, no
+    /// token, or a non-flippable base — a terminal `Deny` (#3111) or a
+    /// `Modify`). Emit ZERO new audit bytes.
     NoOp,
-    /// A verified grant flipped a `Deny`/`Ask` base to `Allow`. Audit a
-    /// capability-grant event naming the token.
+    /// A verified grant flipped an `Ask` (pending human-court) base to
+    /// `Allow`. Audit a capability-grant event naming the token.
     Granted {
         /// The authorising root id.
         root_id: String,
@@ -824,9 +826,17 @@ pub enum GrantOutcome {
 ///
 /// Pure identity when: `base == Allow`, capabilities disabled, `mode` is not
 /// Enforce, or no token is presented. Otherwise a token that [`verify`]s and
-/// covers the request flips a `Deny`/`Ask` (pending/approve) base to `Allow`
-/// (audited grant); a token that fails to verify leaves the base UNCHANGED
-/// (audited reject). `Modify`/`Allow` bases are never touched.
+/// covers the request flips ONLY an `Ask` (pending/approve human-court) base
+/// to `Allow` (audited grant); a token that fails to verify leaves the base
+/// UNCHANGED (audited reject).
+///
+/// A `Deny` is TERMINAL and is never token-flippable (#3111): it is an
+/// explicit operator/rule-derived refusal (a `[permissions]` rule, a
+/// `HookDecision::Deny`, an Enforce-mode `Ask` promotion, or a substrate
+/// `GovernanceRefusal`), and [`verify`] does not consult those permission
+/// rules — so a covering delegated token must not override it. A `Deny` (like
+/// `Modify`/`Allow`) is returned untouched as [`GrantOutcome::NoOp`] BEFORE
+/// [`verify`] runs, so no path from a `Deny` base can reach `Allow`.
 ///
 /// The `Ask`→`Allow` flip is only reachable when [`verify`] succeeds, which
 /// already requires the request op to fit under the issuer ceiling — so a
@@ -847,8 +857,22 @@ pub fn apply_capability_grant(
     let Some(tok) = token else {
         return (base, GrantOutcome::NoOp);
     };
-    // Only Deny / Ask(pending) are flippable.
-    if !matches!(base, Decision::Deny(_) | Decision::Ask(_)) {
+    // #3111 — an operator/rule-derived Deny is TERMINAL; only an `Ask`
+    // (a pending human court) base is flippable. Every `Deny` that reaches
+    // this joiner is an explicit refusal authored by the operator's
+    // permission surface — a `[permissions]` rule, a `HookDecision::Deny`,
+    // an Enforce-mode promotion of an unwired `Ask`, or a substrate
+    // `GovernanceRefusal` shadowed in via `apply_capability_grant_gov`.
+    // `verify` checks only the token's version / issuer / HMAC chain /
+    // caveats / issuer ceiling — it NEVER consults the permission rules that
+    // produced the Deny — so letting a covering token flip a Deny would let a
+    // delegated (possibly attenuated, AI-held) token silently bypass a
+    // standing operator refusal. Delegation-over-deny is not the trust model
+    // on the certified path: a token may satisfy a pending court, never
+    // override a Deny. Returning here BEFORE `verify` makes the property
+    // STRUCTURAL — no code path from a `Deny` (or `Modify`) base can reach
+    // `Decision::Allow`.
+    if !matches!(base, Decision::Ask(_)) {
         return (base, GrantOutcome::NoOp);
     }
     match verify(tok, cfg, req) {
@@ -973,8 +997,9 @@ pub fn governed_action_name(action: crate::models::GovernedAction) -> &'static s
 
 /// Join a capability grant onto the gate-level
 /// [`crate::models::GovernanceDecision`]. Delegates the decision algebra to
-/// the pure [`apply_capability_grant`] (mapping `Deny(refusal)`→`Deny` and
-/// `Pending(id)`→`Ask` for the flippability check) and — critically —
+/// the pure [`apply_capability_grant`] (mapping `Deny(refusal)`→`Deny`
+/// (terminal, #3111) and `Pending(id)`→`Ask` (the only flippable base) for
+/// the flippability check) and — critically —
 /// returns the ORIGINAL `base` value untouched on every non-granted
 /// outcome, so a reject is byte-identical to the legacy decision including
 /// the typed refusal envelope.
@@ -1803,18 +1828,26 @@ mod tests {
     }
 
     #[test]
-    fn apply_grant_flips_deny_and_ask_on_valid_token() {
+    fn apply_grant_deny_is_terminal_ask_flips_on_valid_token() {
+        // #3111 — a token that fully verifies AND covers the tuple must NOT
+        // flip an operator/rule-derived Deny; only an Ask (pending court) is
+        // liftable.
         let (tok, cfg, _, _) = mint_fixture(vec![
             Caveat::OpCeiling(OpLevel::Write),
             Caveat::ExpiresAt(9_999_999_999),
         ]);
         let r = req("Store", "n", "a", 1);
-        // Deny → Allow
+        // Deny is TERMINAL: base unchanged, and the token is never even
+        // consulted (NoOp, not Granted/Rejected).
         let (d, out) =
             apply_capability_grant(Decision::Deny("nope".into()), &cfg, true, Some(&tok), &r);
-        assert_eq!(d, Decision::Allow);
-        assert!(matches!(out, GrantOutcome::Granted { .. }));
-        // Ask(pending) → Allow
+        assert_eq!(d, Decision::Deny("nope".into()), "operator Deny must stand");
+        assert_eq!(
+            out,
+            GrantOutcome::NoOp,
+            "a covering token must not turn a Deny into a grant/reject"
+        );
+        // Ask(pending) → Allow (no regression: the legitimate court lift).
         let (d2, out2) =
             apply_capability_grant(Decision::Ask("court".into()), &cfg, true, Some(&tok), &r);
         assert_eq!(d2, Decision::Allow);
@@ -1850,10 +1883,19 @@ mod tests {
     fn apply_grant_reject_leaves_base_unchanged() {
         let (tok, cfg, _, _) = mint_fixture(vec![Caveat::ExpiresAt(100)]);
         let r = req("Store", "n", "a", 500); // expired
+        // An Ask base DOES reach `verify`; a failed verify leaves it unchanged
+        // and audits a reject.
         let (d, out) =
-            apply_capability_grant(Decision::Deny("orig".into()), &cfg, true, Some(&tok), &r);
-        assert_eq!(d, Decision::Deny("orig".into()));
+            apply_capability_grant(Decision::Ask("court".into()), &cfg, true, Some(&tok), &r);
+        assert_eq!(d, Decision::Ask("court".into()));
         assert_eq!(out, GrantOutcome::Rejected(CapReject::Expired));
+        // #3111 — a Deny base short-circuits to NoOp BEFORE `verify`, so an
+        // expired (or any) token never produces a Rejected outcome from a
+        // Deny: the terminal-Deny property holds structurally.
+        let (d2, out2) =
+            apply_capability_grant(Decision::Deny("orig".into()), &cfg, true, Some(&tok), &r);
+        assert_eq!(d2, Decision::Deny("orig".into()));
+        assert_eq!(out2, GrantOutcome::NoOp);
     }
 
     #[test]

--- a/tests/g10_capability_tokens.rs
+++ b/tests/g10_capability_tokens.rs
@@ -110,7 +110,11 @@ fn attenuation_cannot_escalate_forge_by_removal_is_bad_chain() {
 #[test]
 fn every_reject_leaves_base_unchanged_and_audits_reject() {
     let cfg = config(OpLevel::Write, true);
-    let base = Decision::Deny("policy".to_string());
+    // #3111 — the reject path is exercised from an `Ask` (pending court)
+    // base, the only flippable base; a `Deny` short-circuits to NoOp before
+    // `verify` and so never produces a Rejected outcome (see
+    // `deny_base_is_terminal_before_verify`).
+    let base = Decision::Ask("court".to_string());
 
     // Build one representative token for each reject class.
     let good = token(vec![Caveat::ExpiresAt(9_999_999_999)]);
@@ -193,7 +197,10 @@ fn every_reject_leaves_base_unchanged_and_audits_reject() {
 }
 
 #[test]
-fn valid_token_flips_deny_and_ask() {
+fn valid_token_lifts_ask_only_deny_is_terminal() {
+    // #3111 — a token that verifies AND covers the tuple lifts only an `Ask`
+    // (pending human court). An operator/rule-derived `Deny` is terminal and
+    // is NEVER flipped by any token.
     let cfg = config(OpLevel::Write, true);
     let t = token(vec![
         Caveat::OpCeiling(OpLevel::Write),
@@ -201,13 +208,42 @@ fn valid_token_flips_deny_and_ask() {
     ]);
     let r = request("Store", "n", 1);
 
+    // Deny stays Deny — the covering token is not even consulted (NoOp).
     let (d, o) = apply_capability_grant(Decision::Deny("x".into()), &cfg, true, Some(&t), &r);
-    assert_eq!(d, Decision::Allow);
-    assert!(matches!(o, GrantOutcome::Granted { .. }));
+    assert_eq!(d, Decision::Deny("x".into()));
+    assert_eq!(o, GrantOutcome::NoOp);
 
+    // Ask lifts to Allow (no regression).
     let (d2, o2) = apply_capability_grant(Decision::Ask("court".into()), &cfg, true, Some(&t), &r);
     assert_eq!(d2, Decision::Allow);
     assert!(matches!(o2, GrantOutcome::Granted { .. }));
+}
+
+#[test]
+fn deny_base_is_terminal_before_verify() {
+    // #3111 — regardless of the token's validity (a perfect covering token,
+    // an expired one, or a forged one), a `Deny` base returns NoOp with the
+    // base byte-identical: the joiner short-circuits before `verify`, so no
+    // token class can ever turn a `Deny` into `Allow` or even a `Rejected`.
+    let cfg = config(OpLevel::Write, true);
+    let r = request("Store", "n", 1);
+    let good = token(vec![
+        Caveat::OpCeiling(OpLevel::Write),
+        Caveat::ExpiresAt(9_999_999_999),
+    ]);
+    let expired = token(vec![Caveat::ExpiresAt(10)]);
+    let mut forged = good.clone();
+    forged.root_sig[0] ^= 0xFF;
+    for (name, tok) in [("good", &good), ("expired", &expired), ("forged", &forged)] {
+        let (d, o) =
+            apply_capability_grant(Decision::Deny("secrets".into()), &cfg, true, Some(tok), &r);
+        assert_eq!(
+            d,
+            Decision::Deny("secrets".into()),
+            "{name}: Deny must stand"
+        );
+        assert_eq!(o, GrantOutcome::NoOp, "{name}: Deny must not reach verify");
+    }
 }
 
 #[test]
@@ -357,11 +393,13 @@ mod gate_wiring {
         .expect("count pending")
     }
 
-    /// A valid, in-caveat token flips the owner-policy Deny to Allow at
-    /// the WIRED sqlite gate; every reject class leaves the base Deny
-    /// byte-identical to the no-token decision.
+    /// #3111 — an operator/rule-derived owner-policy Deny is TERMINAL at the
+    /// WIRED sqlite gate: NEITHER a valid, in-caveat covering token NOR any
+    /// reject-class token flips it; the base Deny stays byte-identical to the
+    /// no-token decision. (The legitimate `Pending→Allow` court lift is
+    /// covered by `sqlite_gate_pending_flip_and_ceiling_court_guard`.)
     #[test]
-    fn sqlite_gate_valid_token_flips_deny_rejects_leave_base() {
+    fn sqlite_gate_operator_deny_is_terminal_even_with_valid_token() {
         let (_perm, _cap) = pin_gates(config(OpLevel::Admin, true));
         let conn = db::open(std::path::Path::new(":memory:")).unwrap();
         let ns = "g10gate/owner";
@@ -385,12 +423,14 @@ mod gate_wiring {
             other => panic!("owner policy must deny a non-owner store, got {other:?}"),
         };
 
-        // Valid token ⇒ Allow.
+        // #3111 — a valid, fully in-caveat covering token must NOT flip the
+        // operator Deny: it is terminal, so the base refusal stands
+        // byte-identical (same reason) as with no token at all.
         let good = token(vec![
             Caveat::OpCeiling(OpLevel::Write),
             Caveat::ExpiresAt(9_999_999_999),
         ]);
-        let flipped = db::enforce_governance(
+        let with_good = db::enforce_governance(
             &conn,
             GovernedAction::Store,
             ns,
@@ -401,10 +441,13 @@ mod gate_wiring {
             Some(&good),
         )
         .unwrap();
-        assert!(
-            matches!(flipped, GovernanceDecision::Allow),
-            "valid in-caveat token must flip Deny→Allow at the wired gate, got {flipped:?}"
-        );
+        match with_good {
+            GovernanceDecision::Deny(refusal) => assert_eq!(
+                refusal.reason, base_reason,
+                "a valid covering token must leave the operator Deny byte-identical (#3111)"
+            ),
+            other => panic!("operator Deny must be terminal, got {other:?}"),
+        }
 
         // Reject classes ⇒ base decision UNCHANGED (same refusal reason).
         let expired = token(vec![Caveat::ExpiresAt(10)]);
@@ -602,11 +645,14 @@ mod gate_wiring {
         clear_capability_config_for_test();
     }
 
-    /// Every grant and every reject at the wired gate lands a forensic
-    /// audit row (capability-grant / capability-reject), and a malformed
+    /// A grant and a reject at the wired gate each land a forensic audit row
+    /// (capability-grant / capability-reject) — both from an `Approve`
+    /// (pending court) base, the only flippable base (#3111). A malformed
     /// edge presentation (feature ON) lands a DENY capability-reject
     /// (fail-closed fix: the edge parse now refuses the request, so the
-    /// forensic decision is `deny`, not the pre-fix advisory `warn`).
+    /// forensic decision is `deny`, not the pre-fix advisory `warn`). And a
+    /// terminal operator `Deny` (owner policy) emits ZERO capability rows even
+    /// with a perfect covering token.
     #[test]
     fn audit_rows_for_grant_reject_and_edge_parse() {
         let (_perm, _cap) = pin_gates(config(OpLevel::Admin, true));
@@ -614,8 +660,12 @@ mod gate_wiring {
         ai_memory::governance::audit::init(audit_dir.path(), None).expect("init forensic sink");
 
         let conn = db::open(std::path::Path::new(":memory:")).unwrap();
-        let ns = "g10audit/owner";
-        seed_policy(&conn, ns, &policy(GovernanceLevel::Owner), "ai:alice");
+        // Grant / reject rows come from a pending (approve) base.
+        let ns = "g10audit/approve";
+        seed_policy(&conn, ns, &policy(GovernanceLevel::Approve), "ai:alice");
+        // Terminal-Deny namespace: an owner policy that must emit NO cap rows.
+        let deny_ns = "g10audit/owner";
+        seed_policy(&conn, deny_ns, &policy(GovernanceLevel::Owner), "ai:alice");
         let payload = serde_json::json!({"title": "x"});
 
         let good = token(vec![
@@ -623,6 +673,7 @@ mod gate_wiring {
             Caveat::ExpiresAt(9_999_999_999),
         ]);
         let expired = token(vec![Caveat::ExpiresAt(10)]);
+        // Grant: good token lifts the pending court → capability-grant row.
         let _ = db::enforce_governance(
             &conn,
             GovernedAction::Store,
@@ -634,6 +685,7 @@ mod gate_wiring {
             Some(&good),
         )
         .unwrap();
+        // Reject: expired token against the pending base → capability-reject.
         let _ = db::enforce_governance(
             &conn,
             GovernedAction::Store,
@@ -643,6 +695,19 @@ mod gate_wiring {
             None,
             &payload,
             Some(&expired),
+        )
+        .unwrap();
+        // Terminal Deny: even a perfect covering token emits NO capability
+        // row (the joiner short-circuits to NoOp before any audit).
+        let _ = db::enforce_governance(
+            &conn,
+            GovernedAction::Store,
+            deny_ns,
+            "ai:mallory",
+            None,
+            None,
+            &payload,
+            Some(&good),
         )
         .unwrap();
         // Malformed edge presentation with the feature ON is now a TYPED
@@ -662,7 +727,7 @@ mod gate_wiring {
         });
         let grant = grant.expect("a capability-grant row must land");
         assert_eq!(grant["decision"], "allow");
-        assert_eq!(grant["payload"]["flipped_from"], "deny");
+        assert_eq!(grant["payload"]["flipped_from"], "pending");
         assert_eq!(grant["payload"]["issuer"], ISSUER);
         assert_eq!(grant["actor"], "ai:mallory");
 
@@ -672,6 +737,21 @@ mod gate_wiring {
                 && r["rule_id"] == "expired"
         });
         assert!(reject.is_some(), "a capability-reject row must land");
+
+        // #3111 — the terminal-Deny namespace emitted ZERO capability rows.
+        let deny_cap_rows: Vec<&serde_json::Value> = rows
+            .iter()
+            .filter(|r| {
+                r["payload"]["namespace"] == deny_ns
+                    && r["kind"]
+                        .as_str()
+                        .is_some_and(|k| k.starts_with("capability-"))
+            })
+            .collect();
+        assert!(
+            deny_cap_rows.is_empty(),
+            "a terminal operator Deny must emit ZERO capability rows, got {deny_cap_rows:?}"
+        );
 
         let parse_deny = rows.iter().find(|r| {
             r["kind"].as_str() == Some("capability-reject")
@@ -916,7 +996,9 @@ mod pg_parity {
         let payload = serde_json::json!({"title": "parity"});
         let cases: Vec<(&str, Option<&CapabilityToken>, &str, &str)> = vec![
             ("no_token", None, intruder, "deny"),
-            ("valid", Some(&good), intruder, "allow"),
+            // #3111 — the owner-policy Deny is a terminal operator refusal; a
+            // valid, fully covering token must NOT flip it on EITHER backend.
+            ("valid", Some(&good), intruder, "deny"),
             ("expired", Some(&expired), intruder, "deny"),
             ("wrong_ns", Some(&wrong_ns), intruder, "deny"),
             ("tampered", Some(&tampered), intruder, "deny"),


### PR DESCRIPTION
## Summary

GA-blocking security fix (#3111), ruled **FREEZE 20-0 (unanimous)** by the 3×7 adversarial GA panel under the mission-critical North Star (security pillar: operator permission rules can NEVER be bypassed by AI agents, 100% of the time).

`apply_capability_grant` — the write-gate joiner behind `apply_at_gate` / `enforce_governance`, on **both** the sqlite and postgres gates — treated a `Deny` base as flippable alongside `Ask`:

```rust
if !matches!(base, Decision::Deny(_) | Decision::Ask(_)) { return (base, GrantOutcome::NoOp); }
match verify(tok, cfg, req) { Ok(..) => (Decision::Allow, ...), Err(reject) => (base, ...) }
```

A holder of a valid delegated capability token whose caveat chain + issuer ceiling covered the in-flight `(action, namespace)` tuple could flip an **explicit operator/rule-derived `Deny`** to `Allow`. `verify` checks only the token's version / issuer / HMAC chain / caveats / issuer ceiling — it **never** consults the permission rules that produced the `Deny` — so a delegated (possibly attenuated, AI-held) token silently bypassed a standing operator refusal (e.g. a `[permissions]` "no writes to `secrets/*`" rule, or an owner-policy namespace Deny).

## Finding (Deny provenance)

`governance::Decision::Deny(String)` carries **no provenance discriminant** — the string is only a reason. Every `Deny` reaching the joiner (directly, or shadowed in from `GovernanceDecision::Deny(refusal)` via `apply_capability_grant_gov`) is an operator / rule / hook / mode-derived refusal. There is **no legitimately token-flippable `Deny`**, so `Decision::Deny(_)` is simply removed from the flippable match (as the ruling anticipated).

## The fix

An operator/rule-derived `Deny` is now **terminal**. The joiner short-circuits every non-`Ask` base (a `Deny` or a `Modify`) to `GrantOutcome::NoOp` **before** `verify` runs, so no code path from a `Deny` base can reach `Allow` — the property is **structural**, not conditional (fail-closed by construction). Only an `Ask`/`Pending` (a pending human court) base remains liftable — the intended delegation model; delegation-over-deny is not.

Zero product-API change for compliant flows. A token presented against a `Deny` is now inert (no grant, no new audit bytes). `rust-1.98`: the joiner keeps its validated-type / fail-closed contract (ERRORS-09), and the change removes a match arm rather than adding fallible logic.

## Tests (live regressions)

- **Pure joiner** (`tests/g10_capability_tokens.rs`, `src/governance/capability.rs`): a token that verifies AND covers the tuple cannot flip a `Deny` (NoOp); `deny_base_is_terminal_before_verify` proves a good/expired/forged token all leave a `Deny` byte-identical without reaching `verify`; an `Ask` base still lifts to `Allow`.
- **Wired sqlite gate**: `sqlite_gate_operator_deny_is_terminal_even_with_valid_token` — a valid, fully in-caveat covering token leaves the owner-policy Deny byte-identical.
- **sqlite/postgres parity matrix**: the `valid` case now expects `deny` on **both** backends (terminal Deny is cross-backend).
- **Forensic audit**: a terminal Deny emits **zero** capability rows; grant/reject rows now come from an `Approve` (Pending) base.
- **R9 default-on** (`src/config.rs`): rewritten to assert Deny-terminal + Pending-widens (the legitimate delegated power the owner token retains).

## Verification (all green locally)

- `cargo fmt --all --check`; `bash scripts/check-hardcoded-literals.sh` → PASS
- `cargo check --all-targets` (default) → PASS
- `cargo clippy --all-targets -- -D warnings -D clippy::all -D clippy::pedantic` on **all four legs** (default, `sal`, `sal-postgres`, `vectorlite`) → PASS
- Structural suite (all 10 required) → PASS, incl. `qual_10_module_size_ceiling` (config.rs 14,104 ≤ 14,140 ceiling — no bump needed) and `qual_6_7_legacy_error_type_ceiling`
- Affected unit + integration tests (`g10_capability_tokens`, the joiner unit tests, the R9 test) → PASS

The pg parity `#[tokio::test]` skips without a live `AI_MEMORY_TEST_POSTGRES_URL`; CI runs the postgres leg.

## Scope

Confined to `src/governance/*` + tests + docs; **no** `src/federation/*` or `src/identity/*` source changed, so **no cert §7 amend required**. No SSOT pins affected (no new MCP tools / routes / CLI verbs / schema versions / param names). CHANGELOG `[Unreleased]` updated. Frozen shipped-v0.9.0 release notes left intact (editing shipped history would falsify what shipped).

Closes #3111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY
