### PR TITLE
fix(ci): un-red the certified-postgres cert gate under the fleet umask (#3117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (CI — certified-postgres cert gate RED since the #3198 key-dir hardening, #3117 SHIP-BLOCKER)
+
+- **#3117 (CI / GA ship-blocker) — the `cert-postgres-age.yml` "Cluster-A
+  cert-posture armability gate" was RED because the #3198 key-directory
+  permission hardening refuses the cert-gate harness's own key dirs on the
+  self-hosted `linux-fed` runner.** `scripts/check-bootstrap-cert-gate.sh`
+  mints throwaway Ed25519 keypairs into `mkdir -p` directories (LEG A's
+  `KEYDIR_A`, LEG B's node/witness/recorder + empty-custody dirs). The #3198
+  whole-chain gate (`identity::keypair::enforce_key_dir_secure`,
+  `KEY_DIR_FORBIDDEN_BITS = 0o022`) refuses a group- or world-WRITABLE key
+  directory — deliberately tuned to ACCEPT a default-`umask 022` tree (mode
+  0755, readable but not writable). The self-hosted cert runner runs the fleet
+  `umask 0002`, so a bare `mkdir -p` was born 0775 (group-writable) and every
+  `identity generate` refused with "key directory … is group- or
+  world-writable (mode 775)". LEG A aborted at "could not mint an R40 approver
+  pubkey" (exit 3) BEFORE `doctor --posture` ran, reding the whole gate. Fixed
+  by forcing `umask 022` at the top of the harness so every directory it
+  creates is born 0755 — the exact mode #3198 was built to accept — with no
+  other behavioural change (strictly tighter than the fleet default, never
+  looser). Harness-only: no production keystore posture change, no
+  federation-wire or `AI_MEMORY_FED_*` change, so the §7 re-cert trigger does
+  not fire. The pre-existing R40-approver enrollment in LEG A's
+  `posture_pg_env()` was already correct.
+
 ### Security (#2555 — `schema_version` unconstrained fleet kill-switch, GA-blocker)
 
 - **#2555 (availability / data-integrity, GA-blocker) — `schema_version` was

--- a/scripts/check-bootstrap-cert-gate.sh
+++ b/scripts/check-bootstrap-cert-gate.sh
@@ -33,6 +33,26 @@
 #   AI_MEMORY_BIN=/path/to/ai-memory scripts/check-bootstrap-cert-gate.sh
 set -uo pipefail
 
+# #3117 — normalise to the STANDARD umask before creating ANY key directory.
+# LEG A / LEG B mint throwaway Ed25519 keypairs into `mkdir -p` directories
+# (KEYDIR_A, KEYDIR_B, WDIR_B, RDIR_B, the empty witness/recorder dirs,
+# KEYDIR_D/E). The #3198 whole-chain key-dir gate
+# (`identity::keypair::enforce_key_dir_secure`, `KEY_DIR_FORBIDDEN_BITS=0o022`)
+# REFUSES a group- or world-WRITABLE key directory: a second local UID could
+# swap in an attacker-controlled matched `.priv`/`.pub` pair. That gate is
+# deliberately tuned to ACCEPT a default-`umask 022` tree (mode 0755, readable
+# but not writable) and REFUSE only the write bits. The self-hosted
+# `linux-fed` cert runner (this fleet) runs `umask 0002`, so a bare `mkdir -p`
+# is born 0775 — group-writable — and every `identity generate` refuses with
+# "key directory … is group- or world-writable (mode 775)". That aborted LEG
+# A at "could not mint an R40 approver pubkey" (exit 3) BEFORE `doctor
+# --posture` ever ran, reding the cert gate. Forcing `umask 022` here makes
+# every directory this script creates born 0755 — the exact mode #3198 was
+# built to accept — with no other behavioural change (it is stricter than the
+# fleet default, never looser). Keeps the fix in the harness, not in the
+# production keystore posture, which is correct as-is.
+umask 022
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 # Absolute so the `cd "$WORK_B"` bring-up subshells below still resolve it.


### PR DESCRIPTION
Closes #3117

## TL;DR
The `cert-postgres-age.yml` **"Cluster-A cert-posture armability gate"** (the top cert-lane ship-blocker) has been RED. The real cause is **not** a keyless `posture_pg_env()` (that was already fixed — LEG A enrolls the R40 approver key correctly). It is the **#3198 key-directory permission hardening refusing the cert-gate harness's own key directories** on the self-hosted `linux-fed` runner. One-line harness fix: force `umask 022`.

## Root cause (verified, not assumed)
`scripts/check-bootstrap-cert-gate.sh` mints throwaway Ed25519 keypairs into `mkdir -p` directories (LEG A `KEYDIR_A`; LEG B node/witness/recorder + empty-custody dirs). The #3198 whole-chain gate (`identity::keypair::enforce_key_dir_secure`, `KEY_DIR_FORBIDDEN_BITS = 0o022`) **refuses a group-/world-WRITABLE key directory** — a second local UID could swap in an attacker-controlled matched `.priv`/`.pub` pair, defeating every downstream file-level control.

That gate is **deliberately** tuned to ACCEPT a default-`umask 022` tree (mode `0755` — readable, not writable) and refuse only the WRITE bits (`keypair.rs` `KEY_DIR_FORBIDDEN_BITS` doc). The self-hosted cert runner runs the **fleet `umask 0002`** (documented at `keypair.rs:215-217`: "This fleet's `umask 0002` leaves live `~/.config/ai-memory/keys` at `0o775` — the defect #3198 exists to refuse"). So the harness's bare `mkdir -p` dirs are born `0775` — **group-writable** — and every `identity generate` refuses:

```
Error: key directory /tmp/.../keys is group- or world-writable (mode 775); refusing to use it. ... Restore with: chmod 0700 ... (#3198)
```

LEG A aborts at **"could not mint an R40 approver pubkey" (exit 3)** BEFORE `doctor --posture` ever runs → the whole gate reds.

## Fix
Force `umask 022` at the top of the harness so every directory it creates is born `0755` — the exact mode #3198 was built to accept — with **no other behavioural change** (strictly tighter than the fleet default, never looser). The fix lives in the **harness**, not the production keystore posture, which is correct as-is.

## Why NOT a §7 re-cert / posture-encoding change
- The posture-encoding SSOTs (`set_fully_hardened_env`, `doctor.rs` posture helper, `docs/deploy/enterprise-federation.env`, and the script's `posture_pg_env()`) are **unchanged**. LEG A already enrolled the R40 approver key.
- The diff touches only `scripts/check-bootstrap-cert-gate.sh` + `CHANGELOG.md` — **no `src/`, no federation-wire path, no `AI_MEMORY_FED_*` identifier**.
- `scripts/check-cert-expiry.sh` (the mechanized §7 gate) confirms: `PASS — federation-wire surface unchanged`.

## Verification (local, under the fleet `umask 0002`)
| Check | Result |
|---|---|
| `bash scripts/check-bootstrap-cert-gate.sh` (fleet umask 0002, before fix) | RED — exit 3 "could not mint an R40 approver pubkey" |
| `bash scripts/check-bootstrap-cert-gate.sh` (after fix) | **CERT-BOOTSTRAP GATE: PASS** — LEG A exit 0, control #15 = pg compensating control, all 15 rows PASS |
| `bash scripts/check-cert-expiry.sh` | PASS — federation-wire surface unchanged |
| `bash scripts/check-cert-expiry.sh --self-test` | OK (all lanes) |
| `bash scripts/check-hardcoded-literals.sh` | PASS |
| `cargo fmt --all --check` | clean (zero Rust changed) |

No Rust source changed, so the clippy/structural-suite legs are unaffected (CI runs the full matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY