### PR TITLE
fix(governance): align capability.rs inline tests to #3111 terminal-Deny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (CI — `cargo test --lib` RED: two inline capability tests still asserted pre-#3111 flip-Deny, #3111 follow-up)
+
+- **#3111 follow-up (CI / test-only) — the Per-Module Coverage `cargo test
+  --lib` job was RED because two inline `#[cfg(test)]` unit tests in
+  `src/governance/capability.rs` still asserted the OLD "a covering token flips
+  a Deny to Allow" behavior that #3111 removed.** #3111 made a rule-derived
+  (operator) `Deny` TERMINAL in the capability-token grant joiner:
+  `apply_capability_grant`/`apply_capability_grant_gov` return the `Deny` base
+  UNCHANGED with `GrantOutcome::NoOp` BEFORE `verify()` runs, and `apply_at_gate`
+  likewise leaves an operator `Deny` in place — only an `Ask`/`Pending` (a
+  pending human court) base lifts to `Allow` on a valid covering token. The
+  crown-jewel authz invariant is that an operator permission rule can never be
+  bypassed by an AI-held (possibly attenuated) token. The g10 integration tests
+  were updated with #3111 but these two inline unit tests were missed:
+  `gov_joiner_flips_deny_and_pending_and_preserves_base_on_reject` (renamed to
+  `gov_joiner_deny_terminal_pending_flips_preserves_base_on_reject`) asserted
+  `Deny("nope") → Allow`+`Granted`, and
+  `apply_at_gate_flips_when_enabled_and_verified` (renamed to
+  `apply_at_gate_operator_deny_terminal_pending_flips`) asserted
+  `Deny("deny") → Allow` at the gate. Both now assert the terminal-Deny
+  invariant (the original refusal envelope stands, `NoOp` at the joiner) while
+  keeping — and, at the gate, strengthening with an explicit `Pending → Allow`
+  case — the legitimate pending-court lift path. Test-only: no production code
+  changed, no `src/federation`/`src/identity` touched, so the §7 re-cert
+  trigger does not fire.
+
 ### Fixed (CI — certified-postgres cert gate RED since the #3198 key-dir hardening, #3117 SHIP-BLOCKER)
 
 - **#3117 (CI / GA ship-blocker) — the `cert-postgres-age.yml` "Cluster-A

--- a/src/governance/capability.rs
+++ b/src/governance/capability.rs
@@ -1984,17 +1984,31 @@ mod tests {
     }
 
     #[test]
-    fn gov_joiner_flips_deny_and_pending_and_preserves_base_on_reject() {
+    fn gov_joiner_deny_terminal_pending_flips_preserves_base_on_reject() {
         use crate::models::GovernanceDecision;
         let (tok, cfg, _, _) = mint_fixture(vec![
             Caveat::OpCeiling(OpLevel::Write),
             Caveat::ExpiresAt(9_999_999_999),
         ]);
         let r = req("Store", "n", "a", 1);
-        // Deny → Allow on a valid token.
+        // #3111 — an operator/rule-derived Deny is TERMINAL: even a fully
+        // covering token must NOT flip it. The token is never consulted
+        // (NoOp, not Granted), and the ORIGINAL refusal envelope stands.
         let (d, out) = apply_capability_grant_gov(refusal("nope"), &cfg, true, Some(&tok), &r);
-        assert_eq!(d, GovernanceDecision::Allow);
-        assert!(matches!(out, GrantOutcome::Granted { .. }));
+        match d {
+            GovernanceDecision::Deny(refu) => {
+                assert_eq!(
+                    refu.reason, "nope",
+                    "the operator Deny must stand unchanged"
+                );
+            }
+            other => panic!("operator Deny must stay terminal, got {other:?}"),
+        }
+        assert_eq!(
+            out,
+            GrantOutcome::NoOp,
+            "a covering token must not turn a Deny into a grant/reject"
+        );
         // Pending → Allow on a valid token.
         let (d2, out2) = apply_capability_grant_gov(
             GovernanceDecision::Pending(String::new()),
@@ -2005,15 +2019,32 @@ mod tests {
         );
         assert_eq!(d2, GovernanceDecision::Allow);
         assert!(matches!(out2, GrantOutcome::Granted { .. }));
-        // Reject (expired) → the ORIGINAL refusal envelope is returned.
+        // Reject (expired) on the only base that reaches `verify` — a
+        // Pending court — returns the ORIGINAL base byte-identical with a
+        // Rejected outcome (reject preserves the base envelope).
         let expired = req("Store", "n", "a", 99_999_999_999);
-        let (d3, out3) =
-            apply_capability_grant_gov(refusal("original"), &cfg, true, Some(&tok), &expired);
+        let (d3, out3) = apply_capability_grant_gov(
+            GovernanceDecision::Pending("court-7".into()),
+            &cfg,
+            true,
+            Some(&tok),
+            &expired,
+        );
         match d3 {
-            GovernanceDecision::Deny(refu) => assert_eq!(refu.reason, "original"),
+            GovernanceDecision::Pending(id) => assert_eq!(id, "court-7"),
             other => panic!("base must be unchanged on reject, got {other:?}"),
         }
         assert_eq!(out3, GrantOutcome::Rejected(CapReject::Expired));
+        // #3111 — a Deny base short-circuits to NoOp BEFORE `verify`, so even
+        // an expired (would-reject) token never turns that Deny into a
+        // Rejected outcome: the terminal-Deny envelope is returned verbatim.
+        let (dd, outd) =
+            apply_capability_grant_gov(refusal("original"), &cfg, true, Some(&tok), &expired);
+        match dd {
+            GovernanceDecision::Deny(refu) => assert_eq!(refu.reason, "original"),
+            other => panic!("operator Deny must stay terminal, got {other:?}"),
+        }
+        assert_eq!(outd, GrantOutcome::NoOp);
         // Allow base → identity NoOp.
         let (d4, out4) =
             apply_capability_grant_gov(GovernanceDecision::Allow, &cfg, true, Some(&tok), &r);
@@ -2050,7 +2081,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_at_gate_flips_when_enabled_and_verified() {
+    fn apply_at_gate_operator_deny_terminal_pending_flips() {
         use crate::models::{GovernanceDecision, GovernedAction};
         let _cap = crate::config::lock_capability_config_for_test();
         let (tok, cfg, _, _) = mint_fixture(vec![
@@ -2058,6 +2089,8 @@ mod tests {
             Caveat::ExpiresAt(9_999_999_999),
         ]);
         crate::config::set_active_capability_config(cfg);
+        // #3111 — an operator Deny is TERMINAL at the gate: a fully covering
+        // token confers nothing, the refusal envelope is returned verbatim.
         let d = apply_at_gate(
             refusal("deny"),
             GovernedAction::Store,
@@ -2065,7 +2098,27 @@ mod tests {
             "ai:x",
             Some(&tok),
         );
-        assert_eq!(d, GovernanceDecision::Allow);
+        match d {
+            GovernanceDecision::Deny(r) => {
+                assert_eq!(r.reason, "deny", "operator Deny is terminal at the gate");
+            }
+            other => panic!("operator Deny must stand at the gate, got {other:?}"),
+        }
+        // Positive path still works: a legitimate pending court IS liftable at
+        // the gate by the same covering token (the gate is not a blanket
+        // no-op — only Deny is terminal).
+        let dp = apply_at_gate(
+            GovernanceDecision::Pending(String::new()),
+            GovernedAction::Store,
+            "ns",
+            "ai:x",
+            Some(&tok),
+        );
+        assert_eq!(
+            dp,
+            GovernanceDecision::Allow,
+            "a pending court must lift on a covering token"
+        );
         // An expired presentation leaves the base unchanged.
         let (past, cfg2, _, _) = mint_fixture(vec![Caveat::ExpiresAt(1)]);
         crate::config::set_active_capability_config(cfg2);


### PR DESCRIPTION
## Problem

The Per-Module Coverage `cargo test --lib` job was RED on the release tip. Two inline `#[cfg(test)]` unit tests in `src/governance/capability.rs` still asserted the **pre-#3111** "a covering token flips a `Deny` to `Allow`" behavior.

#3111 made a rule-derived (operator) `Deny` **TERMINAL** in the capability-token grant joiner:
- `apply_capability_grant` / `apply_capability_grant_gov` return the `Deny` base **UNCHANGED** with `GrantOutcome::NoOp` **BEFORE** `verify()` runs.
- `apply_at_gate` likewise leaves an operator `Deny` in place.
- Only an `Ask`/`Pending` (a pending human court) base lifts to `Allow` on a valid covering token.

The g10 integration tests (`tests/g10_capability_tokens.rs`) were updated with #3111, but these two inline unit tests were missed.

## Fix (test-only — no production code changed)

- `gov_joiner_flips_deny_and_pending_and_preserves_base_on_reject` → **`gov_joiner_deny_terminal_pending_flips_preserves_base_on_reject`**: the `Deny("nope") → Allow`+`Granted` assertion now asserts the `Deny` is terminal (refusal envelope stands, `NoOp`). The reject-preserves-base block used a `Deny` base — which no longer reaches `verify` — so it is retargeted to a `Pending` base to still exercise a genuine `Rejected(Expired)` outcome, plus an added assertion that an expired token cannot move a `Deny` (terminal, `NoOp`).
- `apply_at_gate_flips_when_enabled_and_verified` → **`apply_at_gate_operator_deny_terminal_pending_flips`**: the `Deny("deny") → Allow` assertion now asserts terminal-`Deny` at the gate, strengthened with an explicit `Pending → Allow` case proving the gate still lifts a legitimate pending court (i.e. it is not a blanket no-op).

The whole inline module was scanned; all other grant/gate tests (`apply_grant_deny_is_terminal_ask_flips_on_valid_token`, `apply_grant_reject_leaves_base_unchanged`, `apply_at_gate_identity_*`) already encode terminal-Deny correctly. No test is weakened — each fixed test still proves the crown-jewel authz invariant: an operator permission rule can never be bypassed by an AI-held (possibly attenuated) token.

Touches no `src/federation` or `src/identity`, so the cert §7 re-cert trigger does not fire.

## Verification

- `cargo test --features sal,sal-postgres --lib -- governance::capability` → **41 passed** (the exact suite that was failing).
- `cargo test --features sal-postgres --test g10_capability_tokens -- --include-ignored` → **13/13** (no regression).
- `cargo clippy --features sal-postgres --tests -- -D warnings -D clippy::all -D clippy::pedantic` → clean.
- `cargo fmt --all --check` → clean.
- `qual_10_module_size_ceiling`, `qual_6_7_legacy_error_type_ceiling` → green (no ceiling bump needed; test-only additions, no new `Result<_,String>` signatures).

Closes #3111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY5jkDeSKBWAe4eopdywtY