### PR TITLE
fix(swarm-harness): repair rubric packaging defects and derive mission progress from the call log (#3440)

### DIFF
--- a/changelog.d/3440.fixed.md
+++ b/changelog.d/3440.fixed.md
@@ -1,0 +1,10 @@
+Swarm harness (test-only): repair presentation defects in per-agent rubric
+replies instead of discarding them — strip code fences and surrounding prose
+before re-extracting the JSON object, drop unknown extra keys, and truncate an
+over-long `free_text` to 600 characters rather than invalidating the five
+structured judgements that came with it. Repairs are named per agent and
+counted separately from raw parses in `nhi-audit.json`, so the strictness stays
+visible and a repaired rubric is never mistaken for a clean one. Mission
+progress is now also derived from the call log (`mission_evidence`), which
+stamps every dispatch with its origin so a scripted choreography's write can
+never be counted as an agent's mission work.

--- a/sdk/python/swarm/__main__.py
+++ b/sdk/python/swarm/__main__.py
@@ -20,7 +20,8 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
-from swarm.audit import build_nhi_report, render_nhi_report, write_audit_artifacts
+from swarm.audit import (build_nhi_report, harness_dispatches, render_nhi_report,
+                         write_audit_artifacts)
 from swarm.choreography import (collect_assessments, negative_authorization_evidence,
                                 nhi_assessment, run_all)
 from swarm.config import ConfigError, SwarmConfig
@@ -105,6 +106,25 @@ def _usage_block(
              f"usage.json -> {path}"]
     return "\n".join(lines)
 
+def _mission_partial(progress: dict[str, dict[str, object]]) -> dict[str, int]:
+    """Fleet totals for both mission views: the strict flags and the call-log
+    evidence (#3440). A strict 0 is then always reported next to what the agents
+    actually did — e.g. 61 summaries stored, 0 of them in the shared namespace.
+    """
+    rows = list(progress.values())
+    return {name: sum(int(bool(row[key])) if isinstance(row[key], bool) else int(row[key])
+                      for row in rows)
+            for name, key in (
+                ("summary_stored", "summary_stored"),
+                ("lineage_proved", "lineage_proved"),
+                ("facts_stored_total", "facts_stored"),
+                ("summary_stored_evidence", "summary_stored_evidence"),
+                ("summary_in_shared_namespace", "summary_in_shared_namespace"),
+                ("lineage_proved_evidence", "lineage_proved_evidence"),
+                ("facts_stored_evidence", "facts_stored_evidence"),
+            )}
+
+
 def _auditor_verdict(assessment: str | None) -> str:
     """The auditor's FINAL verdict.
 
@@ -145,13 +165,16 @@ async def _main() -> int:
         try:
             await swarm.provision()
             await swarm.run()
-            negative_evidence = await negative_authorization_evidence(swarm)
-            results = await run_all(swarm)
-            assessments = await collect_assessments(swarm)
-            reconcile_result = swarm.call_log.reconcile(coverage)
-            assessment_result, assessment = await nhi_assessment(
-                swarm, results, reconcile_result=reconcile_result,
-                negative_evidence=negative_evidence)
+            # Everything past the agent run is HARNESS-dispatched: stamped so
+            # the mission evidence never mistakes a probe for an agent's work.
+            with harness_dispatches():
+                negative_evidence = await negative_authorization_evidence(swarm)
+                results = await run_all(swarm)
+                assessments = await collect_assessments(swarm)
+                reconcile_result = swarm.call_log.reconcile(coverage)
+                assessment_result, assessment = await nhi_assessment(
+                    swarm, results, reconcile_result=reconcile_result,
+                    negative_evidence=negative_evidence)
             results.append(assessment_result)
             final_reconcile = swarm.call_log.reconcile(coverage)
             _write_journals(swarm, assessment=assessment)
@@ -167,12 +190,7 @@ async def _main() -> int:
                 model=config.model_slug, model_override_reason=config.model_override_reason)
             report["call_log_reconcile"] = final_reconcile
             report["mission_progress"] = swarm.mission_progress()
-            prog = report["mission_progress"].values()
-            report["mission_partial"] = {
-                "summary_stored": sum(p["summary_stored"] for p in prog),
-                "lineage_proved": sum(p["lineage_proved"] for p in prog),
-                "facts_stored_total": sum(p["facts_stored"] for p in prog),
-            }
+            report["mission_partial"] = _mission_partial(report["mission_progress"])
             print("\n" + render_nhi_report(report))
             journal_dir = os.environ.get("SWARM_JOURNAL_DIR")
             if journal_dir:

--- a/sdk/python/swarm/audit.py
+++ b/sdk/python/swarm/audit.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import json
 import re
 from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -47,6 +49,10 @@ class CallLog:
         entry = {
             "agent_id": agent_id,
             "module": module,  # daemon base URL the call went to (multi-module runs)
+            # "agent" (the GLM loop chose it) or "harness" (a scripted
+            # choreography/probe dispatched it AS the agent). Mission evidence
+            # counts only agent-originated work (#3440).
+            "origin": _call_origin,
             "tool": tool,
             "args": redact(args),
             "ok": bool(outcome.ok),
@@ -78,6 +84,28 @@ class CallLog:
 
 
 _active_call_log: CallLog | None = None
+#: Origin stamped on every logged dispatch; see :func:`harness_dispatches`.
+_call_origin = "agent"
+
+
+@contextmanager
+def harness_dispatches() -> Iterator[None]:
+    """Stamp every dispatch inside the block as HARNESS-originated (#3440).
+
+    The scripted choreographies, the authorization probes, and the rubric
+    attestations all dispatch AS an agent, so their writes are indistinguishable
+    from mission work in the call log — a consensus vote or an untitled
+    ``derives_from`` sweep link would otherwise be counted as an agent's own
+    lineage. They run strictly AFTER ``Swarm.run()`` has returned, on the one
+    orchestrating task, so a module-global marker is unambiguous here.
+    """
+    global _call_origin
+    previous = _call_origin
+    _call_origin = "harness"
+    try:
+        yield
+    finally:
+        _call_origin = previous
 
 
 def set_call_log(log: CallLog | None) -> None:
@@ -102,33 +130,240 @@ class AgentAssessment:
     free_text: str
     assessment_invalid: bool = False
     error: str | None = None
+    #: True when the reply needed one of the bounded repairs below to parse.
+    #: A repaired rubric is USABLE but never silently so: the repair kinds are
+    #: recorded per agent and counted separately in the report.
+    repaired: bool = False
+    repairs: tuple[str, ...] = ()
+    #: Verbatim head of the model reply, kept ONLY for repaired/invalid rubrics
+    #: so an auditor can see exactly what the strictness reacted to.
+    raw_excerpt: str = ""
+
+
+#: The rubric fields :data:`swarm.choreography._RUBRIC_PROMPT` demands.
+_RUBRIC_FIELDS = frozenset({
+    "recall_usefulness", "latency_acceptable", "failures_encountered",
+    "isolation_respected", "would_rely_on_it", "free_text",
+})
+#: Hard cap on the rubric's free-text field. Over-long text is TRUNCATED (the
+#: prose is commentary, never durable memory data), not thrown away with the
+#: five structured judgements that came with it.
+FREE_TEXT_LIMIT = 600
+#: Excerpt of a repaired/invalid reply retained as evidence.
+_RAW_EXCERPT_CHARS = 600
+_FENCE_RE = re.compile(r"```[A-Za-z0-9_+-]*\s*(?P<body>.*?)\s*```", re.S)
+
+
+def _first_json_object(text: str) -> str | None:
+    """Return the first balanced ``{...}`` span, ignoring braces inside strings."""
+    depth = 0
+    start = -1
+    in_string = False
+    escaped = False
+    for index, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}" and depth:
+            depth -= 1
+            if depth == 0:
+                return text[start:index + 1]
+    return None
+
+
+def _json_candidates(raw: str) -> list[tuple[str, str]]:
+    """The verbatim reply first, then bounded repairs, as ``(text, repair)``."""
+    candidates: list[tuple[str, str]] = [(raw, "")]
+    candidates.extend((match.group("body"), "code_fence_stripped")
+                      for match in _FENCE_RE.finditer(raw))
+    embedded = _first_json_object(raw)
+    if embedded is not None and embedded != raw.strip():
+        candidates.append((embedded, "json_extracted"))
+    return candidates
+
+
+def _validate_rubric(value: dict[str, Any], repairs: list[str]) -> dict[str, Any]:
+    """Validate the six rubric fields; raise ``ValueError`` on anything unfixable."""
+    extra = set(value) - _RUBRIC_FIELDS
+    if extra:
+        value = {name: item for name, item in value.items() if name in _RUBRIC_FIELDS}
+        repairs.append("extra_fields_dropped")
+    missing = _RUBRIC_FIELDS - set(value)
+    if missing:
+        raise ValueError("rubric is missing required fields: " + ", ".join(sorted(missing)))
+    score = value["recall_usefulness"]
+    failures = value["failures_encountered"]
+    if type(score) is not int or not 1 <= score <= 5:
+        raise ValueError("recall_usefulness must be an integer from 1 to 5")
+    for field in ("latency_acceptable", "isolation_respected", "would_rely_on_it"):
+        if type(value[field]) is not bool:
+            raise ValueError(f"{field} must be boolean")
+    if (not isinstance(failures, list) or
+            any(not isinstance(x, list) or len(x) != 2 or
+                any(not isinstance(y, str) for y in x) for x in failures)):
+        raise ValueError("failures_encountered must be [[tool, what], ...]")
+    free_text = value["free_text"]
+    if not isinstance(free_text, str):
+        raise ValueError("free_text must be a string")
+    if len(free_text) > FREE_TEXT_LIMIT:
+        value = {**value, "free_text": free_text[:FREE_TEXT_LIMIT]}
+        repairs.append("free_text_truncated")
+    return value
 
 
 def parse_assessment(agent_id: str, raw: str) -> AgentAssessment:
-    """Strictly parse the fixed per-agent rubric; malformed input is invalid."""
-    try:
-        value = json.loads(raw)
-        required = {"recall_usefulness", "latency_acceptable", "failures_encountered",
-                    "isolation_respected", "would_rely_on_it", "free_text"}
-        if not isinstance(value, dict) or set(value) != required:
-            raise ValueError("rubric must contain exactly the six required fields")
-        score = value["recall_usefulness"]
-        failures = value["failures_encountered"]
-        if type(score) is not int or not 1 <= score <= 5:
-            raise ValueError("recall_usefulness must be an integer from 1 to 5")
-        for field in ("latency_acceptable", "isolation_respected", "would_rely_on_it"):
-            if type(value[field]) is not bool:
-                raise ValueError(f"{field} must be boolean")
-        if (not isinstance(failures, list) or
-                any(not isinstance(x, list) or len(x) != 2 or
-                    any(not isinstance(y, str) for y in x) for x in failures)):
-            raise ValueError("failures_encountered must be [[tool, what], ...]")
-        if not isinstance(value["free_text"], str) or len(value["free_text"]) > 600:
-            raise ValueError("free_text must be a string of at most 600 characters")
-        return AgentAssessment(agent_id=agent_id, **value)
-    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+    """Parse the fixed per-agent rubric, repairing only PRESENTATION defects.
+
+    Strictness is unchanged for the five structured judgements: a wrong type, an
+    out-of-range score, a missing field, or a reply with no JSON object at all is
+    still ``assessment_invalid`` — the run never invents an opinion an NHI did
+    not state. What IS repaired is packaging the model got wrong around an
+    otherwise complete rubric (#3440):
+
+    * a reply wrapped in a ``` code fence, or JSON preceded/followed by prose,
+    * unknown extra keys alongside the six required ones,
+    * a ``free_text`` longer than :data:`FREE_TEXT_LIMIT` (truncated).
+
+    Every repair is named in :attr:`AgentAssessment.repairs` and counted
+    separately by :func:`build_nhi_report`, so a repaired rubric can never be
+    mistaken for one the model returned clean.
+    """
+    text = raw or ""
+    repairs: list[str] = []
+    value: dict[str, Any] | None = None
+    for candidate, repair in _json_candidates(text):
+        try:
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict):
+            value = parsed
+            if repair:
+                repairs.append(repair)
+            break
+    if value is None:
         return AgentAssessment(agent_id, None, None, [], None, None, "",
-                               assessment_invalid=True, error=str(exc))
+                               assessment_invalid=True,
+                               error="no JSON rubric object in the model reply",
+                               raw_excerpt=text[:_RAW_EXCERPT_CHARS])
+    try:
+        fields = _validate_rubric(value, repairs)
+    except (ValueError, TypeError) as exc:
+        return AgentAssessment(agent_id, None, None, [], None, None, "",
+                               assessment_invalid=True, error=str(exc),
+                               repairs=tuple(repairs),
+                               raw_excerpt=text[:_RAW_EXCERPT_CHARS])
+    return AgentAssessment(agent_id=agent_id, **fields, repaired=bool(repairs),
+                           repairs=tuple(repairs),
+                           raw_excerpt=text[:_RAW_EXCERPT_CHARS] if repairs else "")
+
+
+#: Titles the HARNESS writes through an agent's own dispatch (choreographies,
+#: authorization probes, rubric attestations). They are the harness's evidence,
+#: never the agent's mission work, so they are excluded from mission evidence.
+HARNESS_TITLE_PREFIXES = (
+    "consensus-vote-", "consensus-", "nhi-audit-", "approval-decision-",
+    "isolation-canary-", "replay-probe-", "full-surface-", "AI-NHI swarm assessment",
+)
+_MEMORY_ID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+#: A summary must fold at least this many of the agent's OWN earlier memory ids
+#: to count as summary-shaped without carrying the mission title. One citation
+#: is a fact referencing an observation; several is a consolidation.
+_SUMMARY_MIN_CITATIONS = 2
+
+
+def _is_harness_title(title: str) -> bool:
+    return title.startswith(HARNESS_TITLE_PREFIXES)
+
+
+def mission_evidence(entries: list[dict[str, Any]], *,
+                     shared_namespace: str | None = None) -> dict[str, dict[str, Any]]:
+    """Derive per-agent mission progress from the CALL LOG, not from a fixed tag.
+
+    #3440: the in-agent ``summary_stored`` flag only fired when the model both
+    titled the summary exactly and named the shared namespace, so a run where
+    256 agents wrote summaries into their own namespace reported 0 summaries and
+    an unexplainable 0% completion. Evidence here is read back from what was
+    actually dispatched, and each signal is reported separately rather than
+    collapsed into one pass/fail:
+
+    * ``summary_stored`` — an ``ok`` store titled ``mission-summary-<agent_id>``
+      (the mission's own contract) OR a durable store (tier ``long``, or
+      collective/team scope, or the shared namespace) whose content cites at
+      least :data:`_SUMMARY_MIN_CITATIONS` memory ids the SAME agent stored
+      earlier in the run — i.e. a consolidation with derived-from lineage.
+    * ``summary_in_shared_namespace`` — of those, whether any actually landed in
+      the shared namespace (the part of the mission the agents missed).
+    * ``lineage_proved`` — an ``ok`` ``consolidate`` or ``derives_from`` link.
+    * ``facts_stored`` — every other ``ok`` agent store.
+
+    Harness-written rows are excluded by their logged ``origin`` (see
+    :func:`harness_dispatches`), falling back to
+    :data:`HARNESS_TITLE_PREFIXES` for journals written before that field
+    existed, so a choreography's consensus vote can never be counted as an
+    agent's mission work.
+    """
+    evidence: dict[str, dict[str, Any]] = {}
+
+    def _for(agent_id: str) -> dict[str, Any]:
+        return evidence.setdefault(agent_id, {
+            "summary_stored": False, "summary_count": 0,
+            "summary_in_shared_namespace": False, "lineage_proved": False,
+            "facts_stored": 0, "_ids": [],
+        })
+
+    for entry in entries:
+        agent_id = str(entry.get("agent_id") or "")
+        if not agent_id:
+            continue
+        item = _for(agent_id)  # every agent in the log gets a row, even an empty one
+        # `origin` (#3440) is authoritative when present; journals written before
+        # it existed fall back to excluding the harness's own titles, which
+        # cannot catch an untitled scripted link — see the tests.
+        origin = entry.get("origin")
+        args = entry.get("args") if isinstance(entry.get("args"), dict) else {}
+        title = str(args.get("title") or "")
+        harness = origin != "agent" if origin is not None else _is_harness_title(title)
+        if not entry.get("ok") or harness:
+            continue
+        tool = entry.get("tool")
+        if tool in ("consolidate", "link"):
+            if tool == "consolidate" or args.get("relation") == "derives_from":
+                item["lineage_proved"] = True
+            continue
+        if tool != "store":
+            continue
+        content = str(args.get("content") or "")
+        cited = {value for value in _MEMORY_ID_RE.findall(content) if value in item["_ids"]}
+        durable = (args.get("tier") == "long" or args.get("scope") in ("collective", "team")
+                   or (shared_namespace is not None and args.get("namespace") == shared_namespace))
+        is_summary = (title == f"mission-summary-{agent_id}"
+                      or (durable and len(cited) >= _SUMMARY_MIN_CITATIONS))
+        if is_summary:
+            item["summary_stored"] = True
+            item["summary_count"] += 1
+            if shared_namespace is not None and args.get("namespace") == shared_namespace:
+                item["summary_in_shared_namespace"] = True
+        else:
+            item["facts_stored"] += 1
+        found = _MEMORY_ID_RE.search(str(entry.get("summary") or ""))
+        if found:
+            item["_ids"].append(found.group(0))
+    for item in evidence.values():
+        del item["_ids"]
+    return evidence
 
 
 def build_nhi_report(*, n_agents: int, completed: int,
@@ -137,6 +372,8 @@ def build_nhi_report(*, n_agents: int, completed: int,
                      model: str | None = None, model_override_reason: str | None = None,
                      ) -> dict[str, Any]:
     valid = [a for a in assessments if not a.assessment_invalid]
+    repaired = [a for a in valid if a.repaired]
+    repair_kinds = Counter(kind for a in assessments for kind in a.repairs)
     failures = Counter(f"{tool}: {what}" for a in valid for tool, what in a.failures_encountered)
     return {
         "model": model,
@@ -146,6 +383,11 @@ def build_nhi_report(*, n_agents: int, completed: int,
         "mission_completed": completed,
         "mission_completion_rate": completed / n_agents if n_agents else 0.0,
         "assessments_valid": len(valid),
+        # Raw = parsed with ZERO repairs; repaired = usable only after a bounded
+        # presentation repair. Both are reported so the strictness stays visible.
+        "assessments_valid_raw": len(valid) - len(repaired),
+        "assessments_repaired": len(repaired),
+        "assessment_repairs": dict(sorted(repair_kinds.items())),
         "assessments_invalid": len(assessments) - len(valid),
         "recall_usefulness_mean": (
             sum(a.recall_usefulness or 0 for a in valid) / len(valid) if valid else None
@@ -165,7 +407,9 @@ def render_nhi_report(report: dict[str, Any]) -> str:
              f"model: {report.get('model')}" + (f"  (override: {report['model_override_reason']})" if report.get('model_override_reason') else ""),
              f"agents: {report['n_agents']}",
              f"mission completion rate: {report['mission_completion_rate']:.1%}",
-             f"valid/invalid rubrics: {report['assessments_valid']}/{report['assessments_invalid']}",
+             f"valid/invalid rubrics: {report['assessments_valid']}/{report['assessments_invalid']}"
+             + f"  (raw {report.get('assessments_valid_raw', report['assessments_valid'])}"
+               f" + repaired {report.get('assessments_repaired', 0)})",
              f"recall usefulness mean: {report['recall_usefulness_mean']}",
              f"latency acceptable: {report['latency_acceptable_count']}",
              f"isolation respected: {report['isolation_respected_count']}",
@@ -174,6 +418,12 @@ def render_nhi_report(report: dict[str, Any]) -> str:
     if report.get("mission_partial"):
         mp = report["mission_partial"]
         lines.append(f"mission partial: summaries {mp['summary_stored']} · lineage {mp['lineage_proved']} · facts {mp['facts_stored_total']}")
+        if "summary_stored_evidence" in mp:
+            lines.append(
+                f"mission evidence (call log): summaries {mp['summary_stored_evidence']}"
+                f" · in shared ns {mp['summary_in_shared_namespace']}"
+                f" · lineage {mp['lineage_proved_evidence']}"
+                f" · facts {mp['facts_stored_evidence']}")
     lines.extend(f"quote [{q['agent_id']}]: {q['free_text']}" for q in report["quotes"])
     lines.append("auditor verdict: " + report["auditor_verdict"])
     return "\n".join(lines)
@@ -190,6 +440,7 @@ def write_audit_artifacts(directory: str | Path, assessments: list[AgentAssessme
         json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-__all__ = ["AgentAssessment", "CallLog", "build_nhi_report", "parse_assessment",
+__all__ = ["FREE_TEXT_LIMIT", "HARNESS_TITLE_PREFIXES", "AgentAssessment", "CallLog",
+           "build_nhi_report", "harness_dispatches", "mission_evidence", "parse_assessment",
            "record_dispatch", "redact", "render_nhi_report", "set_call_log", "utc_now",
            "write_audit_artifacts"]

--- a/sdk/python/swarm/orchestrator.py
+++ b/sdk/python/swarm/orchestrator.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 from ai_memory.attestation import AgentSigningKey
 
 from swarm.agent import SwarmAgent
-from swarm.audit import CallLog, set_call_log
+from swarm.audit import CallLog, mission_evidence, set_call_log
 from swarm.coverage import CoverageTracker
 from swarm.openrouter import OpenRouterClient
 
@@ -197,15 +197,34 @@ class Swarm:
                      and agent.mission_lineage_proved and agent.mission_summary_cites_sources)
                 for agent in self.agents}
 
-    def mission_progress(self) -> dict[str, dict[str, bool]]:
-        """Per-agent breakdown so a 0% strict rate is explainable, not opaque."""
+    def mission_progress(self) -> dict[str, dict[str, object]]:
+        """Per-agent breakdown so a 0% strict rate is explainable, not opaque.
+
+        Each agent carries BOTH views: the strict in-agent flags (which require
+        the summary to be titled AND written to the shared namespace) and the
+        call-log evidence (#3440), which reads back what was actually
+        dispatched. When the two disagree the evidence keys say why — e.g. 61
+        summaries stored but ``summary_in_shared_namespace`` false for all of
+        them is a mission the agents did most of, not a harness that saw none.
+        """
+        evidence = mission_evidence(self.call_log.entries,
+                                    shared_namespace=self.shared_namespace)
+        empty = {"summary_stored": False, "summary_count": 0,
+                 "summary_in_shared_namespace": False, "lineage_proved": False,
+                 "facts_stored": 0}
         return {agent.identity.agent_id: {
             "summary_stored": bool(agent.mission_summary_id),
             "single_summary": agent.mission_summary_count == 1,
             "lineage_proved": agent.mission_lineage_proved,
             "cites_all_sources": agent.mission_summary_cites_sources,
             "facts_stored": len(agent.mission_memory_ids),
-        } for agent in self.agents}
+            "summary_stored_evidence": found["summary_stored"],
+            "summary_count_evidence": found["summary_count"],
+            "summary_in_shared_namespace": found["summary_in_shared_namespace"],
+            "lineage_proved_evidence": found["lineage_proved"],
+            "facts_stored_evidence": found["facts_stored"],
+        } for agent in self.agents
+            for found in (evidence.get(agent.identity.agent_id, empty),)}
 
 
 async def run_swarm(config: SwarmConfig) -> CoverageTracker:

--- a/sdk/python/swarm/tests/test_rubric_repair.py
+++ b/sdk/python/swarm/tests/test_rubric_repair.py
@@ -1,0 +1,319 @@
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+"""#3440 — bounded rubric repair and call-log mission evidence.
+
+Offline only: no OpenRouter, no daemon. The last two tests replay the real
+256-agent journal (``m2-swarm-256x10-20260901T231850Z``) when it is present on
+this machine, and SKIP everywhere else — the synthetic cases above them cover
+the same shapes deterministically.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from swarm.audit import (FREE_TEXT_LIMIT, build_nhi_report, mission_evidence,
+                         parse_assessment, render_nhi_report)
+
+#: The journal this issue was raised from. Overridable for a different run.
+_JOURNAL = Path(os.environ.get(
+    "SWARM_JOURNAL_FIXTURE",
+    "/home/fate_two/v07/v09-dev/.local-runs/journals/m2-swarm-256x10-20260901T231850Z"))
+
+
+def _rubric(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "recall_usefulness": 4,
+        "latency_acceptable": True,
+        "failures_encountered": [["recall", "one timeout"]],
+        "isolation_respected": True,
+        "would_rely_on_it": True,
+        "free_text": "Recall was useful; lineage held.",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_clean_rubric_is_not_marked_repaired() -> None:
+    parsed = parse_assessment("ai:one", json.dumps(_rubric()))
+    assert not parsed.assessment_invalid
+    assert not parsed.repaired
+    assert parsed.repairs == ()
+    # The excerpt is kept ONLY as evidence for a repaired/invalid reply.
+    assert parsed.raw_excerpt == ""
+
+
+def test_code_fence_and_leading_prose_are_stripped() -> None:
+    fenced = "Here is my assessment:\n```json\n" + json.dumps(_rubric()) + "\n```\nHope that helps."
+    parsed = parse_assessment("ai:one", fenced)
+    assert not parsed.assessment_invalid
+    assert parsed.repairs == ("code_fence_stripped",)
+    assert parsed.recall_usefulness == 4
+
+    prose = "Sure — my rubric: " + json.dumps(_rubric()) + " (let me know if you need more)"
+    extracted = parse_assessment("ai:one", prose)
+    assert not extracted.assessment_invalid
+    assert extracted.repairs == ("json_extracted",)
+    # The raw reply is retained verbatim so the strictness stays auditable.
+    assert extracted.raw_excerpt.startswith("Sure — my rubric:")
+
+
+def test_over_long_free_text_is_truncated_not_discarded() -> None:
+    long_text = "x" * 900
+    parsed = parse_assessment("ai:one", json.dumps(_rubric(free_text=long_text)))
+    # #3440: 95/256 agents lost five structured judgements to a long paragraph.
+    assert not parsed.assessment_invalid
+    assert parsed.repairs == ("free_text_truncated",)
+    assert len(parsed.free_text) == FREE_TEXT_LIMIT
+    assert parsed.free_text == long_text[:FREE_TEXT_LIMIT]
+    assert parsed.recall_usefulness == 4 and parsed.would_rely_on_it is True
+
+
+def test_extra_fields_are_dropped_and_counted() -> None:
+    parsed = parse_assessment("ai:one", json.dumps(_rubric(confidence=0.9, notes="hi")))
+    assert not parsed.assessment_invalid
+    assert parsed.repairs == ("extra_fields_dropped",)
+
+
+def test_repairs_compose_and_are_all_reported() -> None:
+    raw = "```\n" + json.dumps(_rubric(free_text="y" * 700, extra=1)) + "\n```"
+    parsed = parse_assessment("ai:one", raw)
+    assert not parsed.assessment_invalid
+    assert set(parsed.repairs) == {"code_fence_stripped", "extra_fields_dropped",
+                                   "free_text_truncated"}
+
+
+@pytest.mark.parametrize("raw", [
+    "",
+    "I could not complete the assessment.",
+    json.dumps(_rubric(recall_usefulness=7)),
+    json.dumps(_rubric(recall_usefulness="4")),
+    json.dumps(_rubric(latency_acceptable="yes")),
+    json.dumps(_rubric(failures_encountered=["recall"])),
+    json.dumps(_rubric(free_text=None)),
+    json.dumps({k: v for k, v in _rubric().items() if k != "isolation_respected"}),
+])
+def test_strictness_is_preserved_for_substantive_defects(raw: str) -> None:
+    """Repair fixes PACKAGING only — a judgement the NHI did not state stays invalid."""
+    parsed = parse_assessment("ai:one", raw)
+    assert parsed.assessment_invalid
+    assert parsed.error
+    assert parsed.recall_usefulness is None and parsed.free_text == ""
+
+
+def test_report_separates_raw_from_repaired() -> None:
+    clean = parse_assessment("ai:one", json.dumps(_rubric()))
+    repaired = parse_assessment("ai:two", json.dumps(_rubric(free_text="z" * 800)))
+    invalid = parse_assessment("ai:three", "no rubric here")
+    report = build_nhi_report(n_agents=3, completed=0,
+                              assessments=[clean, repaired, invalid],
+                              auditor_verdict="FAIL")
+    assert report["assessments_valid"] == 2
+    assert report["assessments_valid_raw"] == 1
+    assert report["assessments_repaired"] == 1
+    assert report["assessments_invalid"] == 1
+    assert report["assessment_repairs"] == {"free_text_truncated": 1}
+    assert "raw 1 + repaired 1" in render_nhi_report(report)
+
+
+# -- call-log mission evidence (#3440 ask 2) --------------------------------
+
+def _store(agent: str, title: str, *, ok: bool = True, memory_id: str = "",
+           **args: object) -> dict[str, object]:
+    return {"agent_id": agent, "tool": "store", "ok": ok,
+            "args": {"title": title, **args},
+            "summary": f"{{'id': '{memory_id}'}}" if memory_id else "{}"}
+
+
+_A = "ai:agent-a"
+_ID1 = "11111111-1111-4111-8111-111111111111"
+_ID2 = "22222222-2222-4222-8222-222222222222"
+
+
+def test_mission_evidence_sees_a_summary_the_strict_flag_misses() -> None:
+    """The observed failure: a titled summary written WITHOUT the shared namespace."""
+    entries = [
+        _store(_A, "Fact 1", content="a", memory_id=_ID1),
+        _store(_A, "Fact 2", content="b", memory_id=_ID2),
+        _store(_A, f"mission-summary-{_A}", content=f"builds on {_ID1} and {_ID2}",
+               scope="collective", tier="long"),
+    ]
+    found = mission_evidence(entries, shared_namespace="m2-shared")[_A]
+    assert found["summary_stored"] is True
+    assert found["summary_count"] == 1
+    # ... and the audit still says the mission requirement was NOT met.
+    assert found["summary_in_shared_namespace"] is False
+    assert found["facts_stored"] == 2
+
+
+def test_mission_evidence_accepts_an_untitled_consolidating_summary() -> None:
+    entries = [
+        _store(_A, "Fact 1", content="a", memory_id=_ID1),
+        _store(_A, "Fact 2", content="b", memory_id=_ID2),
+        _store(_A, "Run wrap-up", content=f"folds {_ID1} + {_ID2}", tier="long",
+               namespace="m2-shared", scope="collective"),
+    ]
+    found = mission_evidence(entries, shared_namespace="m2-shared")[_A]
+    assert found["summary_stored"] and found["summary_in_shared_namespace"]
+    assert found["facts_stored"] == 2
+
+
+def test_mission_evidence_never_counts_harness_or_failed_writes() -> None:
+    entries = [
+        # Harness-written rows dispatched through the agent's own identity.
+        _store(_A, "consensus-vote-abc-0", content="the sky is blue", scope="collective"),
+        _store(_A, f"nhi-audit-{_A}-abc", content=f"cites {_ID1} {_ID2}", scope="collective"),
+        _store(_A, "AI-NHI swarm assessment abc", content="verdict", scope="collective"),
+        # A refused write is not evidence of anything having been stored.
+        _store(_A, f"mission-summary-{_A}", ok=False, content="x", scope="collective"),
+        {"agent_id": _A, "tool": "consolidate", "ok": False,
+         "args": {"ids": [_ID1], "title": "x"}, "summary": "boom"},
+    ]
+    assert mission_evidence(entries, shared_namespace="m2-shared") == {
+        _A: {"summary_stored": False, "summary_count": 0,
+             "summary_in_shared_namespace": False, "lineage_proved": False,
+             "facts_stored": 0}}
+
+
+def test_mission_evidence_lineage_from_consolidate_or_derives_from() -> None:
+    consolidate = [{"agent_id": _A, "tool": "consolidate", "ok": True,
+                    "args": {"ids": [_ID1, _ID2], "title": "phase-1"}, "summary": "{}"}]
+    link = [{"agent_id": _A, "tool": "link", "ok": True,
+             "args": {"source_id": _ID2, "target_id": _ID1, "relation": "derives_from"},
+             "summary": "{}"}]
+    unrelated = [{"agent_id": _A, "tool": "link", "ok": True,
+                  "args": {"source_id": _ID2, "target_id": _ID1, "relation": "relates_to"},
+                  "summary": "{}"}]
+    assert mission_evidence(consolidate)[_A]["lineage_proved"] is True
+    assert mission_evidence(link)[_A]["lineage_proved"] is True
+    assert mission_evidence(unrelated)[_A]["lineage_proved"] is False
+
+
+def test_origin_stamp_excludes_untitled_harness_dispatches() -> None:
+    """What the title filter cannot catch: an untitled scripted derives_from link."""
+    sweep_link = {"agent_id": _A, "tool": "link", "ok": True, "origin": "harness",
+                  "args": {"source_id": _ID2, "target_id": _ID1,
+                           "relation": "derives_from"}, "summary": "{}"}
+    assert mission_evidence([sweep_link])[_A]["lineage_proved"] is False
+    agent_link = {**sweep_link, "origin": "agent"}
+    assert mission_evidence([agent_link])[_A]["lineage_proved"] is True
+
+
+@pytest.mark.asyncio
+async def test_harness_dispatches_stamps_the_call_log(tmp_path) -> None:
+    from swarm.audit import CallLog, harness_dispatches, record_dispatch, set_call_log
+
+    outcome = SimpleNamespace(ok=True, fail_closed=False, summary="{}")
+    log = CallLog(tmp_path)
+    set_call_log(log)
+    try:
+        record_dispatch(_A, "store", {"title": "Fact 1"}, outcome)
+        with harness_dispatches():
+            record_dispatch(_A, "store", {"title": "consensus-vote-1"}, outcome)
+        record_dispatch(_A, "store", {"title": "Fact 2"}, outcome)
+    finally:
+        set_call_log(None)
+    assert [entry["origin"] for entry in log.entries] == ["agent", "harness", "agent"]
+    written = [json.loads(line) for line in
+               (tmp_path / "calls.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert [entry["origin"] for entry in written] == ["agent", "harness", "agent"]
+
+
+# -- replay of the real 256-agent journal ------------------------------------
+
+@pytest.mark.skipif(not (_JOURNAL / "assessments.json").exists(),
+                    reason=f"journal fixture not present: {_JOURNAL}")
+def test_journal_invalid_rubrics_are_now_repairable() -> None:
+    stored = json.loads((_JOURNAL / "assessments.json").read_text(encoding="utf-8"))
+    invalid = [a for a in stored if a["assessment_invalid"]]
+    length_refusals = [a for a in invalid
+                       if a["error"] == "free_text must be a string of at most 600 characters"]
+    # The run as it happened: 156/256 invalid, 95 of them for free-text length.
+    assert (len(stored), len(invalid), len(length_refusals)) == (256, 156, 95)
+
+    # A rubric of exactly that shape (complete, over-long prose) now survives.
+    over_long = parse_assessment("ai:one", json.dumps(_rubric(free_text="q" * 1200)))
+    assert not over_long.assessment_invalid and over_long.repaired
+
+    # Every rubric that WAS valid still parses valid, unchanged and un-repaired.
+    for item in stored:
+        if item["assessment_invalid"]:
+            continue
+        fields = {k: item[k] for k in
+                  ("recall_usefulness", "latency_acceptable", "failures_encountered",
+                   "isolation_respected", "would_rely_on_it", "free_text")}
+        again = parse_assessment(item["agent_id"], json.dumps(fields))
+        assert not again.assessment_invalid and not again.repaired
+        assert again.recall_usefulness == item["recall_usefulness"]
+
+
+@pytest.mark.skipif(not (_JOURNAL / "calls.jsonl").exists(),
+                    reason=f"journal fixture not present: {_JOURNAL}")
+def test_journal_call_log_explains_the_zero_percent_completion() -> None:
+    entries = [json.loads(line) for line in
+               (_JOURNAL / "calls.jsonl").read_text(encoding="utf-8").splitlines() if line]
+    report = json.loads((_JOURNAL / "nhi-audit.json").read_text(encoding="utf-8"))
+    found = mission_evidence(entries, shared_namespace="m2-shared")
+
+    summaries = sum(item["summary_stored"] for item in found.values())
+    in_shared = sum(item["summary_in_shared_namespace"] for item in found.values())
+    lineage = sum(item["lineage_proved"] for item in found.values())
+    facts = sum(item["facts_stored"] for item in found.values())
+
+    # The run reported 0 summaries; the call log shows 61 agents stored one.
+    assert report["mission_partial"]["summary_stored"] == 0
+    assert summaries == 61
+    # ... and none reached the shared namespace, which is WHY completion is 0%.
+    assert in_shared == 0
+    assert report["mission_completion_rate"] == 0.0
+    # Lineage matches the strict counter, plus exactly one legacy artifact: this
+    # journal predates the `origin` stamp, and `full_surface_sweep` dispatches an
+    # UNTITLED derives_from link as agents[0], which no title filter can exclude.
+    # New runs carry origin=harness on that link (see the test below).
+    assert report["mission_partial"]["lineage_proved"] == 120
+    assert lineage == 121
+    assert sum(1 for entry in entries if "origin" in entry) == 0
+    # The summaries the strict accounting mis-filed as plain facts are exactly
+    # the difference (595 + 61).
+    assert facts == 595
+    assert facts + summaries == report["mission_partial"]["facts_stored_total"] == 656
+
+
+def test_mission_progress_carries_both_views_into_the_report() -> None:
+    """End-to-end wiring: strict flags AND call-log evidence reach the report."""
+    from swarm.__main__ import _mission_partial
+    from swarm.audit import CallLog
+    from swarm.orchestrator import Swarm
+
+    agent = SimpleNamespace(
+        identity=SimpleNamespace(agent_id=_A),
+        mission_summary_id=None, mission_summary_count=0,
+        mission_lineage_proved=False, mission_memory_ids=[_ID1, _ID2],
+        mission_summary_cites_sources=False)
+    log = CallLog(None)
+    log.entries = [
+        _store(_A, "Fact 1", content="a", memory_id=_ID1),
+        _store(_A, "Fact 2", content="b", memory_id=_ID2),
+        _store(_A, f"mission-summary-{_A}", content=f"{_ID1} + {_ID2}",
+               scope="collective", tier="long"),
+    ]
+    swarm = SimpleNamespace(agents=[agent], call_log=log, shared_namespace="m2-shared")
+    progress = Swarm.mission_progress(swarm)[_A]
+    # Strict: nothing completed (the summary never reached the shared namespace).
+    assert progress["summary_stored"] is False
+    # Evidence: the summary exists, and the report says where it went wrong.
+    assert progress["summary_stored_evidence"] is True
+    assert progress["summary_in_shared_namespace"] is False
+    assert progress["facts_stored_evidence"] == 2
+
+    report = build_nhi_report(n_agents=1, completed=0, assessments=[],
+                              auditor_verdict="FAIL")
+    report["mission_partial"] = _mission_partial({_A: progress})
+    rendered = render_nhi_report(report)
+    assert "mission partial: summaries 0" in rendered
+    assert "mission evidence (call log): summaries 1 · in shared ns 0" in rendered


### PR DESCRIPTION
Closes #3440

## What
Two funnels turn model output into audit numbers; both under-reported the 256-agent run.

**1. `parse_assessment` repairs PACKAGING, not substance.** Code fences and surrounding prose are stripped and the first balanced JSON object re-extracted; unknown extra keys are dropped; an over-long `free_text` is truncated to 600 chars instead of discarding the five structured judgements that came with it. Strictness is unchanged for substance — wrong type, out-of-range score, missing field, or no JSON object at all is still `assessment_invalid`, so the run never invents an opinion an NHI did not state. Every repair is named per agent (`repairs`, plus a `raw_excerpt` of the reply) and counted separately in `nhi-audit.json` (`assessments_valid_raw`, `assessments_repaired`, `assessment_repairs`).

**2. `summary_stored` is defined from call-log evidence.** The in-agent flag only fired when the model both titled the summary exactly AND named the shared namespace, so 61 stored summaries reported as 0. `mission_evidence()` reads back what was actually dispatched — a summary is the mission's own title, or a durable store folding >= 2 of the agent's own earlier memory ids — and the report now carries **both** views, so a strict 0% always states what the agents did do and which requirement they missed. Because the choreographies dispatch *as* an agent, every logged dispatch is stamped with its `origin` and only agent-originated work counts as evidence.

## Repro (offline, both trees)
```
                       BEFORE (release/v1.0.0)                        AFTER
free_text 900 chars    invalid=True  (95/256 of the run)              invalid=False repairs=('free_text_truncated',)
fenced ```json         invalid=True  "Expecting value: line 1 col 1"  invalid=False repairs=('code_fence_stripped',)
prose + JSON           invalid=True  "Expecting value: line 1 col 1"  invalid=False repairs=('json_extracted',)
score out of range     invalid=True                                   invalid=True  (unchanged — substance)

journal m2-swarm-256x10: reported summary_stored = 0
                       | call-log evidence summaries = 61 | of those in the shared ns = 0
```

## Tests
`sdk/python/swarm/tests/test_rubric_repair.py` — 23 offline tests: every repair kind and composition, the strictness-preserved parametrisation, raw-vs-repaired report counts, the evidence detector (harness rows and failed writes never count), the `origin` stamp, the end-to-end `mission_progress`/`mission_partial` wiring, and two tests that replay the **real** journal `m2-swarm-256x10-20260901T231850Z` (156/256 invalid with 95 length refusals; every previously-valid rubric still parses valid and un-repaired; evidence lineage/fact totals reconcile with the strict counters). The journal tests skip when the fixture is not on the machine.

`cd sdk/python && python -m pytest . -q` -> **122 passed, 4 skipped** (99 before). `python -m ruff check swarm` clean.

Test-only harness (`sdk/python/swarm`); nothing under `src/` or the daemon changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y69UfdxKNcRw7tftCAiNwi
