### PR TITLE
fix(swarm-harness): run A2A choreographies module-locally and report the cross-module boundary explicitly (#3441)

### DIFF
--- a/changelog.d/3441.fixed.md
+++ b/changelog.d/3441.fixed.md
@@ -1,0 +1,10 @@
+Swarm harness (test-only): run the A2A choreographies module-locally. With
+several daemon URLs the launcher round-robins agents across independent data
+tiers, so `producer_consumer` and `consensus_quorum` were asserting cross-tier
+invariants (a notify delivered to one tier read back from another; a
+consolidator reading votes stored on the other tier) that cannot hold until
+node-to-node federation is wired. Every scenario now runs once per module over
+that module's own agents, and the boundary is probed explicitly by
+`cross_module_handoff`, which reports `cross-module: not federated (expected)`
+rather than FAIL — while still failing closed if a message actually crosses an
+unfederated boundary, and asserting real delivery once `SWARM_FEDERATED=1`.

--- a/sdk/python/swarm/README.md
+++ b/sdk/python/swarm/README.md
@@ -50,6 +50,12 @@ choreography.*  ── scripted A2A scenarios ───────────�
   namespace assignment, and staggered launch of N asyncio tasks.
 * **`choreography.py`** — deterministic A2A scenarios exercising isolation,
   attestation, quorum, and replay-guard against the live GLM-driven population.
+  With several daemon URLs the agents are round-robined across INDEPENDENT data
+  tiers ("modules"), so every A2A scenario runs **once per module** over that
+  module's own agents; the boundary itself is probed by `cross_module_handoff`,
+  which expects the handoff NOT to arrive (reported as
+  `cross-module: not federated (expected)`) until `SWARM_FEDERATED=1` says
+  federation is wired — and FAILS if a message crosses an unfederated boundary.
 * **`coverage.py`** — the manifest, the tracker, live reconciliation against
   `GET /api/v1/tools/list` + `GET /api/v1/capabilities`, and the matrix.
 
@@ -66,6 +72,7 @@ choreography.*  ── scripted A2A scenarios ───────────�
 | `SWARM_NAMESPACE_PREFIX` | Isolation-namespace prefix | `swarm` |
 | `OPENROUTER_BASE_URL` | OpenRouter endpoint override | `https://openrouter.ai/api/v1` |
 | `SWARM_JOURNAL_DIR` | Per-agent JSONL journals plus `nhi-assessment.md` | unset (disabled) |
+| `SWARM_FEDERATED` | Assert node-to-node federation IS wired between modules | unset (not federated) |
 
 The model is **pinned** to `glm-5.3-flash` in code (`config.MODEL_ID`); it is
 deliberately not env-overridable so a stray variable cannot swap the attested

--- a/sdk/python/swarm/choreography.py
+++ b/sdk/python/swarm/choreography.py
@@ -60,12 +60,55 @@ class ScenarioResult:
     detail: str
 
 
-async def producer_consumer(swarm: Swarm) -> ScenarioResult:
-    """A -> B message lane; C must not see B's mail (isolation)."""
-    if len(swarm.agents) < 2:
-        return ScenarioResult("producer_consumer", ok=False, detail="need >= 2 agents")
-    a, b = swarm.agents[0], swarm.agents[1]
-    c = swarm.agents[2] if len(swarm.agents) > 2 else None
+def module_of(agent: SwarmAgent) -> str:
+    """The daemon (module) base URL this agent's client is bound to."""
+    return str(getattr(getattr(agent.client, "_client", None), "base_url", "") or "")
+
+
+def modules(swarm: Swarm) -> dict[str, list[SwarmAgent]]:
+    """Group the population by module, preserving spawn order inside each.
+
+    With ``SWARM_MODULES>1`` the launcher round-robins agents across several
+    INDEPENDENT data tiers (separate PG+AGE+pgvector stacks). Agent 0 and agent
+    1 then live on different tiers, so an A2A choreography built from
+    ``agents[0]`` and ``agents[1]`` asserts a cross-tier invariant that cannot
+    hold until node-to-node federation is wired (#3441).
+    """
+    grouped: dict[str, list[SwarmAgent]] = {}
+    for agent in swarm.agents:
+        grouped.setdefault(module_of(agent), []).append(agent)
+    return grouped
+
+
+def _slug(module: str | None) -> str:
+    """Short, title-safe module tag; empty for a single-module run."""
+    if not module:
+        return ""
+    return module.split("://", 1)[-1].strip("/").replace("/", "-") + "-"
+
+
+def _named(name: str, module: str | None) -> str:
+    """Scenario name, tagged with its module when the run is multi-module."""
+    return name if module is None else f"{name}@{module}"
+
+
+def _participants(swarm: Swarm, agents: list[SwarmAgent] | None) -> list[SwarmAgent]:
+    return swarm.agents if agents is None else agents
+
+
+async def producer_consumer(swarm: Swarm, agents: list[SwarmAgent] | None = None,
+                            module: str | None = None) -> ScenarioResult:
+    """A -> B message lane; C must not see B's mail (isolation).
+
+    ``agents`` defaults to the whole population; a multi-module run passes ONE
+    module's agents so the lane stays inside a single data tier.
+    """
+    name = _named("producer_consumer", module)
+    population = _participants(swarm, agents)
+    if len(population) < 2:
+        return ScenarioResult(name, ok=False, detail="need >= 2 agents")
+    a, b = population[0], population[1]
+    c = population[2] if len(population) > 2 else None
 
     subject = f"handoff-{a.identity.agent_id}"
     send = await dispatch(
@@ -91,26 +134,35 @@ async def producer_consumer(swarm: Swarm) -> ScenarioResult:
         c_isolated = not (c_inbox.ok and subject in json.dumps(c_inbox.result, default=str))
 
     ok = send.ok and b_saw and c_isolated
-    return ScenarioResult("producer_consumer", ok=ok,
+    return ScenarioResult(name, ok=ok,
                           detail=f"sent={send.ok} b_saw={b_saw} c_isolated={c_isolated}")
 
 
-async def consensus_quorum(swarm: Swarm) -> ScenarioResult:
-    """N agents attest the same fact into the shared ns; one consolidates."""
-    if len(swarm.agents) < 2:
-        return ScenarioResult("consensus_quorum", ok=False, detail="need >= 2 agents")
+async def consensus_quorum(swarm: Swarm, agents: list[SwarmAgent] | None = None,
+                           module: str | None = None) -> ScenarioResult:
+    """N agents attest the same fact into the shared ns; one consolidates.
+
+    The consolidator must be able to READ every vote, so all voters and the
+    consolidator have to sit on the same module (#3441): a vote stored on one
+    tier is "memory not found" to a consolidator on another.
+    """
+    name = _named("consensus_quorum", module)
+    population = _participants(swarm, agents)
+    if len(population) < 2:
+        return ScenarioResult(name, ok=False, detail="need >= 2 agents")
     fact = "the sky is blue"
     ids: list[str] = []
-    for ordinal, agent in enumerate(swarm.agents):
+    for ordinal, agent in enumerate(population):
         # Votes are "collective"-scoped: a private-scope row is readable only by
         # its author, so the consolidator could not read its peers' votes.
         out = await dispatch(agent.client, agent.identity, "store",
-                             {"title": f"consensus-vote-{_RUN}-{ordinal}", "content": fact,
+                             {"title": f"consensus-vote-{_RUN}-{_slug(module)}{ordinal}",
+                              "content": fact,
                               "namespace": swarm.shared_namespace, "scope": "collective"})
         swarm.coverage.record(out)
         if out.ok and isinstance(out.result, dict) and out.result.get("id"):
             ids.append(str(out.result["id"]))
-    consolidator = swarm.agents[0]
+    consolidator = population[0]
     # The daemon caps one consolidation at 100 sources ("cannot consolidate
     # more than 100 memories at once", measured at 128 agents). Fold the votes
     # in batches of <= 100, then fold the batch results into ONE consensus row.
@@ -122,7 +174,8 @@ async def consensus_quorum(swarm: Swarm) -> ScenarioResult:
         for start in range(0, len(level), batch_size):
             chunk = level[start:start + batch_size]
             cons = await dispatch(consolidator.client, consolidator.identity, "consolidate",
-                                  {"ids": chunk, "title": f"consensus-{_RUN}-{start // batch_size}-{len(level)}",
+                                  {"ids": chunk,
+                                   "title": f"consensus-{_RUN}-{_slug(module)}{start // batch_size}-{len(level)}",
                                    "namespace": swarm.shared_namespace})
             swarm.coverage.record(cons)
             if not cons.ok:
@@ -134,22 +187,25 @@ async def consensus_quorum(swarm: Swarm) -> ScenarioResult:
             break
         level = next_level
     ok = len(ids) >= 2 and cons is not None and cons.ok
-    return ScenarioResult("consensus_quorum", ok=ok,
-                          detail=f"votes={len(ids)} consolidated={cons.ok}")
+    return ScenarioResult(name, ok=ok,
+                          detail=f"votes={len(ids)} consolidated={cons is not None and cons.ok}")
 
 
-async def governance_approval(swarm: Swarm) -> ScenarioResult:
+async def governance_approval(swarm: Swarm, agents: list[SwarmAgent] | None = None,
+                              module: str | None = None) -> ScenarioResult:
     """Proposer requests; approver attests an approval decision + notifies back."""
-    if len(swarm.agents) < 2:
-        return ScenarioResult("governance_approval", ok=False, detail="need >= 2 agents")
-    proposer, approver = swarm.agents[0], swarm.agents[1]
+    name = _named("governance_approval", module)
+    population = _participants(swarm, agents)
+    if len(population) < 2:
+        return ScenarioResult(name, ok=False, detail="need >= 2 agents")
+    proposer, approver = population[0], population[1]
     ask = await dispatch(proposer.client, proposer.identity, "notify",
                          {"to_agent": approver.identity.agent_id,
                           "subject": "approve: publish-report", "body": "please approve"})
     swarm.coverage.record(ask)
     decision = await dispatch(
         approver.client, approver.identity, "store",
-        {"title": f"approval-decision-{_RUN}", "content": "APPROVED: publish-report",
+        {"title": f"approval-decision-{_RUN}-{_slug(module)}", "content": "APPROVED: publish-report",
          "namespace": swarm.shared_namespace, "scope": "collective",
          "tags": ["governance", "approval"]})
     swarm.coverage.record(decision)
@@ -158,7 +214,7 @@ async def governance_approval(swarm: Swarm) -> ScenarioResult:
                           "subject": "approved: publish-report", "body": "granted"})
     swarm.coverage.record(ack)
     ok = ask.ok and decision.ok and ack.ok
-    return ScenarioResult("governance_approval", ok=ok,
+    return ScenarioResult(name, ok=ok,
                           detail=f"asked={ask.ok} decided={decision.ok} acked={ack.ok}")
 
 
@@ -205,12 +261,15 @@ async def replay_guard(agent: SwarmAgent, namespace: str | None = None) -> Scena
     return ScenarioResult("replay_guard", ok=bool(first_id) and guarded, detail=detail)
 
 
-async def full_surface_sweep(swarm: Swarm) -> ScenarioResult:
+async def full_surface_sweep(swarm: Swarm, agents: list[SwarmAgent] | None = None,
+                             module: str | None = None) -> ScenarioResult:
     """Exercise the complete memory lifecycle through the dispatcher."""
-    if not swarm.agents:
-        return ScenarioResult("full_surface_sweep", ok=False, detail="need >= 1 agent")
-    agent = swarm.agents[0]
-    pattern = f"full-surface-{_RUN}"
+    name = _named("full_surface_sweep", module)
+    population = _participants(swarm, agents)
+    if not population:
+        return ScenarioResult(name, ok=False, detail="need >= 1 agent")
+    agent = population[0]
+    pattern = f"full-surface-{_RUN}-{_slug(module)}"
     completed: list[str] = []
 
     async def call(tool: str, args: dict[str, object]):
@@ -223,10 +282,10 @@ async def full_surface_sweep(swarm: Swarm) -> ScenarioResult:
     first = await call("store", {"title": f"{pattern}-source", "content": "source"})
     second = await call("store", {"title": f"{pattern}-target", "content": "target"})
     if not first.ok or not second.ok or not isinstance(first.result, dict) or not isinstance(second.result, dict):
-        return ScenarioResult("full_surface_sweep", False, f"stopped after {','.join(completed)}")
+        return ScenarioResult(name, False, f"stopped after {','.join(completed)}")
     source_id, target_id = first.result.get("id"), second.result.get("id")
     if not source_id or not target_id:
-        return ScenarioResult("full_surface_sweep", False, "store response missing id")
+        return ScenarioResult(name, False, "store response missing id")
 
     # Lineage edges point CHILD -> PARENT: the daemon's temporal lineage guard
     # (#3041) refuses an edge whose target is NEWER than its source, so the
@@ -253,9 +312,9 @@ async def full_surface_sweep(swarm: Swarm) -> ScenarioResult:
             if tool in swarm.coverage.documented_fail_closed and outcome.fail_closed:
                 completed.append(f"{tool}(fail-closed:documented)")
                 continue
-            return ScenarioResult("full_surface_sweep", False,
+            return ScenarioResult(name, False,
                                   f"{tool} failed after {','.join(completed)}: {outcome.summary}")
-    return ScenarioResult("full_surface_sweep", True, " -> ".join(completed))
+    return ScenarioResult(name, True, " -> ".join(completed))
 
 
 #: ~150k tokens at 4 chars/token — safely inside every model we run (GLM 200k, Grok 500k).
@@ -428,22 +487,99 @@ async def collect_assessments(swarm: Swarm) -> list[AgentAssessment]:
     return assessments
 
 
+#: Set to ``1`` once node-to-node federation is configured between the modules.
+#: Until then a cross-module handoff is EXPECTED not to arrive, and the audit
+#: says so explicitly instead of reporting a FAIL it cannot act on (#3441).
+FEDERATED_ENV = "SWARM_FEDERATED"
+
+
+def federation_expected(environ: dict[str, str] | None = None) -> bool:
+    """Whether the operator asserts f1<->f2 federation is wired for this run."""
+    env = os.environ if environ is None else environ
+    return (env.get(FEDERATED_ENV) or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+async def cross_module_handoff(swarm: Swarm, groups: dict[str, list[SwarmAgent]],
+                               *, federated: bool | None = None) -> ScenarioResult:
+    """A on module 1 notifies B on module 2 — the federation boundary probe.
+
+    This is an ASSERTION in both directions, never a rubber stamp:
+
+    * federation not configured (default): the notify must NOT reach the peer
+      module. It landing there would mean two supposedly independent data tiers
+      are leaking into each other — reported as a FAIL.
+    * ``SWARM_FEDERATED=1``: the operator asserts the tiers are federated, so
+      the message MUST arrive; not arriving is a FAIL.
+    """
+    name = "cross_module_handoff"
+    ordered = sorted(groups)
+    if len(ordered) < 2:
+        return ScenarioResult(name, ok=True, detail="single module: not applicable")
+    expect_federated = federation_expected() if federated is None else federated
+    a = groups[ordered[0]][0]
+    b = next((agent for agent in groups[ordered[1]] if agent is not a), None)
+    if b is None:
+        return ScenarioResult(name, ok=False, detail="need an agent on each module")
+
+    subject = f"cross-module-{_RUN}-{a.identity.agent_id}"
+    send = await dispatch(a.client, a.identity, "notify",
+                          {"to_agent": b.identity.agent_id, "subject": subject,
+                           "body": "cross-module handoff probe"})
+    swarm.coverage.record(send)
+    got = await dispatch(b.client, b.identity, "inbox", {"unread_only": True, "limit": 10})
+    swarm.coverage.record(got)
+    crossed = got.ok and subject in json.dumps(got.result, default=str)
+    where = f"{ordered[0]} -> {ordered[1]}"
+    if expect_federated:
+        return ScenarioResult(name, ok=bool(send.ok and crossed),
+                              detail=f"federated: {where} sent={send.ok} b_saw={crossed}")
+    if crossed:
+        return ScenarioResult(
+            name, ok=False,
+            detail=f"cross-module: {where} message CROSSED an unfederated boundary")
+    return ScenarioResult(name, ok=True,
+                          detail=f"cross-module: not federated (expected) [{where}]")
+
+
 async def run_all(swarm: Swarm) -> list[ScenarioResult]:
-    """Run every scenario in sequence against the population."""
-    results = [
-        await producer_consumer(swarm),
-        await consensus_quorum(swarm),
-        await governance_approval(swarm),
-        await full_surface_sweep(swarm),
-    ]
+    """Run every scenario in sequence against the population.
+
+    A single-module run is unchanged. With several modules every A2A scenario
+    runs ONCE PER MODULE over that module's own agents (#3441) — a producer and
+    consumer split across two unfederated tiers can never see each other's
+    inbox, and a consolidator can never read a vote stored on the other tier —
+    and the boundary itself is probed by :func:`cross_module_handoff`.
+    """
+    groups = modules(swarm)
+    if len(groups) <= 1:
+        results = [
+            await producer_consumer(swarm),
+            await consensus_quorum(swarm),
+            await governance_approval(swarm),
+            await full_surface_sweep(swarm),
+        ]
+    else:
+        results = []
+        for module in sorted(groups):
+            agents = groups[module]
+            results.append(await producer_consumer(swarm, agents, module))
+            results.append(await consensus_quorum(swarm, agents, module))
+            results.append(await governance_approval(swarm, agents, module))
+            results.append(await full_surface_sweep(swarm, agents, module))
+        results.append(await cross_module_handoff(swarm, groups))
     if swarm.agents:
         results.append(await replay_guard(swarm.agents[0]))
     return results
 
 
 __all__ = [
+    "FEDERATED_ENV",
     "ScenarioResult",
     "consensus_quorum",
+    "cross_module_handoff",
+    "federation_expected",
+    "module_of",
+    "modules",
     "governance_approval",
     "nhi_assessment",
     "negative_authorization_evidence",

--- a/sdk/python/swarm/tests/test_module_local_choreography.py
+++ b/sdk/python/swarm/tests/test_module_local_choreography.py
@@ -1,0 +1,269 @@
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+"""#3441 — choreographies must stay inside one module (data tier).
+
+Two fake modules, each an ``httpx.MockTransport`` with its OWN inbox and memory
+store and NO federation between them — exactly the shape of the 2-module run
+where ``producer_consumer`` and ``consensus_quorum`` failed because agent 0 sat
+on f2 and agent 1 on f1. Offline: no daemon, no OpenRouter.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from ai_memory import AsyncAiMemoryClient
+from ai_memory.attestation import AgentSigningKey
+from swarm.agent import SwarmAgent
+from swarm.choreography import (consensus_quorum, cross_module_handoff, federation_expected,
+                                module_of, modules, producer_consumer, run_all)
+from swarm.config import SwarmConfig
+from swarm.coverage import CoverageTracker
+from swarm.toolset import AgentIdentity
+from swarm.tests.test_agent_loop_mock import _FakeModel
+from swarm.openrouter import Decision
+
+
+class _Module:
+    """One INDEPENDENT data tier: its own inboxes, memories, and request log."""
+
+    def __init__(self, base_url: str, *, leaks_to: _Module | None = None) -> None:
+        self.base_url = base_url
+        self.inboxes: dict[str, list[dict[str, str]]] = {}
+        self.requests: list[httpx.Request] = []
+        self.rows = 0
+        self.written: dict[tuple[object, object, object], str] = {}
+        #: Only set by the leak test: simulates a boundary that is NOT airtight.
+        self.leaks_to = leaks_to
+
+    def deliver(self, target: str, title: str) -> None:
+        self.inboxes.setdefault(target, []).append({"title": title, "payload": "x"})
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        path, method = request.url.path, request.method
+        agent = request.headers.get("X-Agent-Id", "")
+        if path == "/api/v1/notify":
+            body = json.loads(request.content)
+            self.deliver(body["target_agent_id"], body["title"])
+            if self.leaks_to is not None:
+                self.leaks_to.deliver(body["target_agent_id"], body["title"])
+            return httpx.Response(200, json={"delivered": True})
+        if path == "/api/v1/inbox":
+            target = request.url.params.get("agent_id") or agent
+            return httpx.Response(200, json={"messages": self.inboxes.get(target, [])})
+        if path == "/api/v1/memories" and method == "POST":
+            body = json.loads(request.content)
+            # Replay-guard: the SAME signed envelope dedups to the same row,
+            # never a second durable write (what `replay_guard` asserts).
+            key = (body.get("title"), body.get("signature"), body.get("created_at"))
+            if body.get("signature") and key in self.written:
+                return httpx.Response(200, json={"id": self.written[key], "version": 1})
+            self.rows += 1
+            memory_id = f"{self.base_url}-mem-{self.rows}"
+            if body.get("signature"):
+                self.written[key] = memory_id
+            return httpx.Response(201, json={"id": memory_id, "version": 1})
+        if path == "/api/v1/consolidate":
+            return httpx.Response(201, json={"id": f"{self.base_url}-con"})
+        if path.startswith("/api/v1/memories/") and method == "GET" \
+                and not path.endswith("/lineage"):
+            return httpx.Response(200, json={"memory": {
+                "id": path.rsplit("/", 1)[-1], "tier": "mid", "namespace": "swarm-000",
+                "title": "t", "content": "c", "tags": [], "priority": 5, "confidence": 1.0,
+                "source": "api", "access_count": 0, "created_at": "2026-09-01T00:00:00Z",
+                "updated_at": "2026-09-01T00:00:00Z", "metadata": {}}, "links": []})
+        if path == "/api/v1/recall":
+            return httpx.Response(200, json={"count": 0, "memories": []})
+        if path == "/api/v1/search":
+            return httpx.Response(200, json={"results": [], "count": 0, "query": ""})
+        return httpx.Response(200, json={"ok": True})
+
+
+def _agent_on(module: _Module, ordinal: int) -> SwarmAgent:
+    """One agent bound to ``module`` — its client speaks ONLY to that tier."""
+    agent_id = f"ai:swarm-{ordinal:03d}"
+    namespace = f"swarm-{ordinal:03d}"
+    config = SwarmConfig(base_urls=[module.base_url], n_agents=1, max_steps=1)
+    client = AsyncAiMemoryClient(base_url=module.base_url, agent_id=agent_id)
+    client._client = httpx.AsyncClient(  # noqa: SLF001 - offline transport injection
+        base_url=module.base_url, transport=httpx.MockTransport(module.handle),
+        headers={"X-Agent-Id": agent_id})
+    identity = AgentIdentity(
+        agent_id=agent_id, signing_key=AgentSigningKey.generate(),
+        namespace=namespace, allowed_namespaces={namespace, "swarm-shared"})
+    return SwarmAgent(identity=identity, client=client,
+                      model=_FakeModel(Decision(None, [], {})),  # type: ignore[arg-type]
+                      config=config, coverage=CoverageTracker())
+
+
+def _two_module_swarm(*, leaky: bool = False) -> tuple[SimpleNamespace, _Module, _Module]:
+    """Agents round-robined across two modules, exactly as the launcher does."""
+    second = _Module("http://mod-b")
+    first = _Module("http://mod-a", leaks_to=second if leaky else None)
+    agents = [_agent_on(first if ordinal % 2 == 0 else second, ordinal)
+              for ordinal in range(6)]
+    swarm = SimpleNamespace(agents=agents, coverage=CoverageTracker(),
+                            shared_namespace="swarm-shared")
+    return swarm, first, second
+
+
+async def _aclose(swarm: SimpleNamespace) -> None:
+    for agent in swarm.agents:
+        await agent.aclose()
+
+
+def test_modules_groups_agents_by_client_base_url() -> None:
+    swarm, first, second = _two_module_swarm()
+    grouped = modules(swarm)
+    assert sorted(grouped) == ["http://mod-a", "http://mod-b"]
+    assert [module_of(agent) for agent in grouped["http://mod-a"]] == ["http://mod-a"] * 3
+    # Round-robin really does split agent 0 from agent 1 (the #3441 failure).
+    assert module_of(swarm.agents[0]) != module_of(swarm.agents[1])
+
+
+@pytest.mark.asyncio
+async def test_producer_consumer_is_module_local() -> None:
+    swarm, first, second = _two_module_swarm()
+    try:
+        agents = modules(swarm)["http://mod-a"]
+        result = await producer_consumer(swarm, agents, "http://mod-a")
+    finally:
+        await _aclose(swarm)
+    assert result.ok, result.detail
+    assert result.name == "producer_consumer@http://mod-a"
+    assert "b_saw=True" in result.detail and "c_isolated=True" in result.detail
+    # Every call stayed on one tier; the other module was never touched.
+    assert second.requests == []
+
+
+@pytest.mark.asyncio
+async def test_producer_consumer_across_modules_would_fail() -> None:
+    """The behaviour this issue is about, kept as the negative control."""
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        # agents[0] and agents[1] are on DIFFERENT modules (the old default).
+        result = await producer_consumer(swarm, swarm.agents[:3])
+    finally:
+        await _aclose(swarm)
+    assert not result.ok
+    assert "b_saw=False" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_consensus_quorum_votes_and_consolidates_on_one_module() -> None:
+    swarm, first, second = _two_module_swarm()
+    try:
+        result = await consensus_quorum(swarm, modules(swarm)["http://mod-b"], "http://mod-b")
+    finally:
+        await _aclose(swarm)
+    assert result.ok, result.detail
+    assert result.name == "consensus_quorum@http://mod-b"
+    assert "votes=3" in result.detail
+    # The consolidator only ever saw ids minted by its own module.
+    assert first.requests == []
+
+
+@pytest.mark.asyncio
+async def test_run_all_runs_every_scenario_once_per_module() -> None:
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        results = await run_all(swarm)
+    finally:
+        await _aclose(swarm)
+    names = [result.name for result in results]
+    for scenario in ("producer_consumer", "consensus_quorum", "governance_approval",
+                     "full_surface_sweep"):
+        assert f"{scenario}@http://mod-a" in names
+        assert f"{scenario}@http://mod-b" in names
+        # No un-tagged (cross-module) variant is run any more.
+        assert scenario not in names
+    assert "cross_module_handoff" in names
+    assert "replay_guard" in names
+    failed = [(r.name, r.detail) for r in results if not r.ok]
+    assert failed == [], failed
+
+
+@pytest.mark.asyncio
+async def test_single_module_run_is_unchanged() -> None:
+    only = _Module("http://mod-a")
+    agents = [_agent_on(only, ordinal) for ordinal in range(3)]
+    swarm = SimpleNamespace(agents=agents, coverage=CoverageTracker(),
+                            shared_namespace="swarm-shared")
+    try:
+        results = await run_all(swarm)
+    finally:
+        await _aclose(swarm)
+    names = [result.name for result in results]
+    assert names == ["producer_consumer", "consensus_quorum", "governance_approval",
+                     "full_surface_sweep", "replay_guard"]
+    assert all(result.ok for result in results), [r.detail for r in results if not r.ok]
+
+
+@pytest.mark.asyncio
+async def test_cross_module_handoff_reports_not_federated_rather_than_fail() -> None:
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        result = await cross_module_handoff(swarm, modules(swarm), federated=False)
+    finally:
+        await _aclose(swarm)
+    assert result.ok
+    assert result.detail.startswith("cross-module: not federated (expected)")
+
+
+@pytest.mark.asyncio
+async def test_cross_module_handoff_fails_when_an_unfederated_boundary_leaks() -> None:
+    """Not a rubber stamp: a message that DOES cross is a data-isolation failure."""
+    swarm, _first, _second = _two_module_swarm(leaky=True)
+    try:
+        result = await cross_module_handoff(swarm, modules(swarm), federated=False)
+    finally:
+        await _aclose(swarm)
+    assert not result.ok
+    assert "CROSSED an unfederated boundary" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_cross_module_handoff_asserts_delivery_once_federated() -> None:
+    # SWARM_FEDERATED=1 flips the probe into a real delivery assertion.
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        unfederated = await cross_module_handoff(swarm, modules(swarm), federated=True)
+    finally:
+        await _aclose(swarm)
+    assert not unfederated.ok
+    assert "b_saw=False" in unfederated.detail
+
+    federated_swarm, _a, _b = _two_module_swarm(leaky=True)
+    try:
+        delivered = await cross_module_handoff(federated_swarm, modules(federated_swarm),
+                                               federated=True)
+    finally:
+        await _aclose(federated_swarm)
+    assert delivered.ok
+    assert "b_saw=True" in delivered.detail
+
+
+def test_federation_flag_is_opt_in_and_explicit() -> None:
+    assert federation_expected({}) is False
+    assert federation_expected({"SWARM_FEDERATED": "0"}) is False
+    assert federation_expected({"SWARM_FEDERATED": ""}) is False
+    assert federation_expected({"SWARM_FEDERATED": "1"}) is True
+    assert federation_expected({"SWARM_FEDERATED": "true"}) is True
+
+
+@pytest.mark.asyncio
+async def test_cross_module_handoff_is_not_applicable_on_one_module() -> None:
+    only = _Module("http://mod-a")
+    agents = [_agent_on(only, ordinal) for ordinal in range(2)]
+    swarm = SimpleNamespace(agents=agents, coverage=CoverageTracker(),
+                            shared_namespace="swarm-shared")
+    try:
+        result = await cross_module_handoff(swarm, modules(swarm), federated=False)
+    finally:
+        await _aclose(swarm)
+    assert result.ok and result.detail == "single module: not applicable"

--- a/sdk/python/swarm/tests/test_module_local_choreography.py
+++ b/sdk/python/swarm/tests/test_module_local_choreography.py
@@ -37,6 +37,8 @@ class _Module:
         self.requests: list[httpx.Request] = []
         self.rows = 0
         self.written: dict[tuple[object, object, object], str] = {}
+        #: Ids this tier actually minted; anything else is "memory not found".
+        self.minted: set[str] = set()
         #: Only set by the leak test: simulates a boundary that is NOT airtight.
         self.leaks_to = leaks_to
 
@@ -65,10 +67,17 @@ class _Module:
                 return httpx.Response(200, json={"id": self.written[key], "version": 1})
             self.rows += 1
             memory_id = f"{self.base_url}-mem-{self.rows}"
+            self.minted.add(memory_id)
             if body.get("signature"):
                 self.written[key] = memory_id
             return httpx.Response(201, json={"id": memory_id, "version": 1})
         if path == "/api/v1/consolidate":
+            # A tier can only fold ids IT stored: a vote written to the other
+            # module is "memory not found" here, exactly as the daemon reports.
+            unknown = [i for i in json.loads(request.content).get("ids", [])
+                       if i not in self.minted]
+            if unknown:
+                return httpx.Response(404, json={"error": f"memory not found: {unknown[0]}"})
             return httpx.Response(201, json={"id": f"{self.base_url}-con"})
         if path.startswith("/api/v1/memories/") and method == "GET" \
                 and not path.endswith("/lineage"):
@@ -152,6 +161,18 @@ async def test_producer_consumer_across_modules_would_fail() -> None:
         await _aclose(swarm)
     assert not result.ok
     assert "b_saw=False" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_consensus_quorum_across_modules_cannot_read_its_own_votes() -> None:
+    """The observed failure: votes=256 consolidated=False ("memory not found")."""
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        result = await consensus_quorum(swarm, swarm.agents)
+    finally:
+        await _aclose(swarm)
+    assert not result.ok
+    assert "consolidated=False" in result.detail
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #3441

## What
Under `SWARM_MODULES=2` the launcher round-robins agents across two **independent** data tiers (separate PG+AGE+pgvector stacks, node-to-node federation not wired), so `agents[0]` and `agents[1]` land on different modules. `producer_consumer` notified into f2's tier and read f1's inbox; `consensus_quorum`'s consolidator got "memory not found" for votes stored on the other tier. Both FAILs described the topology, not a product defect.

The control is **participant selection**: agents are grouped by the base URL their client is bound to (`modules()`), every A2A scenario takes its participant list explicitly, and a multi-module run executes each scenario once per module over that module's own agents, tagged `scenario@<module>`. A single-module run is byte-identical to before.

The boundary is no longer implicit. `cross_module_handoff` probes it and is an **assertion in both directions**: by default the handoff must NOT arrive (`cross-module: not federated (expected)`), and a message that *does* cross two supposedly independent tiers is a FAIL; with `SWARM_FEDERATED=1` the operator asserts federation is wired and delivery becomes required.

## Repro (offline, two fake modules with their own inbox + memory store)
```
BEFORE (release/v1.0.0)
[choreography] producer_consumer: FAIL (sent=True b_saw=False c_isolated=True)
[choreography] consensus_quorum:  FAIL (votes=6 consolidated=False)

AFTER
[choreography] producer_consumer@http://mod-a: PASS (sent=True b_saw=True c_isolated=True)
[choreography] consensus_quorum@http://mod-a:  PASS (votes=3 consolidated=True)
[choreography] producer_consumer@http://mod-b: PASS (sent=True b_saw=True c_isolated=True)
[choreography] consensus_quorum@http://mod-b:  PASS (votes=3 consolidated=True)
[choreography] cross_module_handoff: PASS (cross-module: not federated (expected) [http://mod-a -> http://mod-b])
```

## Tests
`sdk/python/swarm/tests/test_module_local_choreography.py` — 12 offline tests over two fake tiers (own inboxes, own memory store, a consolidate that only folds ids *it* minted, and replay-guard dedup): grouping by base URL, module-local producer/consumer and quorum, the negative controls (the old cross-module pairing still fails both ways), `run_all` fan-out per module, the unchanged single-module path, and all three cross-module outcomes — expected non-delivery, a leaking boundary (FAIL), and required delivery under `SWARM_FEDERATED=1`.

`cd sdk/python && python -m pytest . -q` -> **111 passed, 4 skipped** (99 before). `python -m ruff check swarm` clean. `SWARM_FEDERATED` documented in `swarm/README.md`.

Test-only harness (`sdk/python/swarm`); nothing under `src/` or the daemon changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y69UfdxKNcRw7tftCAiNwi
