### PR TITLE
perf(swarm-harness): bound rubric-assessment concurrency and stream partial evidence (#3346)

### DIFF
--- a/changelog.d/3346.changed.md
+++ b/changelog.d/3346.changed.md
@@ -1,0 +1,9 @@
+Swarm harness (test-only): run the per-agent rubric assessments with a bounded
+concurrency (`SWARM_ASSESS_CONCURRENCY`, default 8) instead of one at a time —
+at 256 agents and ~12 s per completion the sequential loop left a ~50 minute
+tail after the mission had finished. Parsing stays strict and each agent's
+usage is now taken from its own response rather than the client-wide
+`last_usage`, which would misattribute tokens as soon as calls overlap.
+Each rubric is streamed to `assessments.partial.jsonl` as it lands so a killed
+run keeps partial evidence, and the assessment phase's wall-clock is reported
+in the NHI AUDIT block and `usage.json`.

--- a/changelog.d/3441.fixed.md
+++ b/changelog.d/3441.fixed.md
@@ -1,0 +1,10 @@
+Swarm harness (test-only): run the A2A choreographies module-locally. With
+several daemon URLs the launcher round-robins agents across independent data
+tiers, so `producer_consumer` and `consensus_quorum` were asserting cross-tier
+invariants (a notify delivered to one tier read back from another; a
+consolidator reading votes stored on the other tier) that cannot hold until
+node-to-node federation is wired. Every scenario now runs once per module over
+that module's own agents, and the boundary is probed explicitly by
+`cross_module_handoff`, which reports `cross-module: not federated (expected)`
+rather than FAIL — while still failing closed if a message actually crosses an
+unfederated boundary, and asserting real delivery once `SWARM_FEDERATED=1`.

--- a/sdk/python/swarm/README.md
+++ b/sdk/python/swarm/README.md
@@ -50,6 +50,12 @@ choreography.*  ── scripted A2A scenarios ───────────�
   namespace assignment, and staggered launch of N asyncio tasks.
 * **`choreography.py`** — deterministic A2A scenarios exercising isolation,
   attestation, quorum, and replay-guard against the live GLM-driven population.
+  With several daemon URLs the agents are round-robined across INDEPENDENT data
+  tiers ("modules"), so every A2A scenario runs **once per module** over that
+  module's own agents; the boundary itself is probed by `cross_module_handoff`,
+  which expects the handoff NOT to arrive (reported as
+  `cross-module: not federated (expected)`) until `SWARM_FEDERATED=1` says
+  federation is wired — and FAILS if a message crosses an unfederated boundary.
 * **`coverage.py`** — the manifest, the tracker, live reconciliation against
   `GET /api/v1/tools/list` + `GET /api/v1/capabilities`, and the matrix.
 
@@ -66,6 +72,7 @@ choreography.*  ── scripted A2A scenarios ───────────�
 | `SWARM_NAMESPACE_PREFIX` | Isolation-namespace prefix | `swarm` |
 | `OPENROUTER_BASE_URL` | OpenRouter endpoint override | `https://openrouter.ai/api/v1` |
 | `SWARM_JOURNAL_DIR` | Per-agent JSONL journals plus `nhi-assessment.md` | unset (disabled) |
+| `SWARM_FEDERATED` | Assert node-to-node federation IS wired between modules | unset (not federated) |
 
 The model is **pinned** to `glm-5.3-flash` in code (`config.MODEL_ID`); it is
 deliberately not env-overridable so a stray variable cannot swap the attested

--- a/sdk/python/swarm/README.md
+++ b/sdk/python/swarm/README.md
@@ -73,6 +73,7 @@ choreography.*  ── scripted A2A scenarios ───────────�
 | `OPENROUTER_BASE_URL` | OpenRouter endpoint override | `https://openrouter.ai/api/v1` |
 | `SWARM_JOURNAL_DIR` | Per-agent JSONL journals plus `nhi-assessment.md` | unset (disabled) |
 | `SWARM_FEDERATED` | Assert node-to-node federation IS wired between modules | unset (not federated) |
+| `SWARM_ASSESS_CONCURRENCY` | Rubric completions in flight at once (bounded, never a blast) | `8` |
 
 The model is **pinned** to `glm-5.3-flash` in code (`config.MODEL_ID`); it is
 deliberately not env-overridable so a stray variable cannot swap the attested
@@ -155,6 +156,7 @@ hand-built model decision — no network, no API key.
 | `<agent>.jsonl` | per-step journal: timestamps, latency, decided tools, full outcomes |
 | `calls.jsonl` | every dispatcher call (agent, tool, redacted args, ok, summary, ts) — reconciles 100% against the coverage matrix |
 | `assessments.json` | per-agent rubric (strict JSON; malformed → `assessment_invalid`) |
+| `assessments.partial.jsonl` | each rubric appended as it lands, so a killed run keeps partial evidence |
 | `nhi-audit.json` | mission completion rate, rubric aggregates, quotes, auditor verdict, negative-evidence probes, model + override reason |
 | `nhi-assessment.md` | the independent auditor's report |
-| `usage.json` | OpenRouter per-generation tokens/cost, account delta, decide latency, model |
+| `usage.json` | OpenRouter per-generation tokens/cost, account delta, decide latency, per-phase wall-clock, model |

--- a/sdk/python/swarm/__main__.py
+++ b/sdk/python/swarm/__main__.py
@@ -69,6 +69,9 @@ def _write_usage(
         "model_override_reason": os.environ.get("SWARM_MODEL_OVERRIDE_REASON") or None,
         "account_usd": {"before": before_data, "after": after_data, "delta": delta},
         "decide_latency_ms": coverage.model_latency_summary(),
+        # Wall-clock per run phase — the assessment tail (#3346) is the one
+        # that grows with the fleet, so it is reported, not just felt.
+        "phase_secs": coverage.phase_secs,
         "completions": {
             "by_agent": coverage.model_usage,
             "total": coverage.model_usage_totals(),
@@ -102,6 +105,8 @@ def _usage_block(
              f"completions {t['requests']}  prompt {t['prompt_tokens']}  completion {t['completion_tokens']}  total {t['total_tokens']} tokens",
              f"generation cost ${t['cost_usd']:.4f}  account delta {'$%.4f' % delta if delta is not None else 'n/a'} (includes daemon embed/LLM calls)",
              f"decide latency ms mean {lat['mean_ms']}  p95 {lat['p95_ms']}  n {lat['n']}",
+             "phase wall-clock secs " + (json.dumps(coverage.phase_secs, sort_keys=True)
+                                         if coverage.phase_secs else "n/a"),
              f"usage.json -> {path}"]
     return "\n".join(lines)
 
@@ -166,6 +171,7 @@ async def _main() -> int:
                 negative_evidence=negative_evidence,
                 model=config.model_slug, model_override_reason=config.model_override_reason)
             report["call_log_reconcile"] = final_reconcile
+            report["assessment_phase_secs"] = coverage.phase_secs.get("assessments")
             report["mission_progress"] = swarm.mission_progress()
             prog = report["mission_progress"].values()
             report["mission_partial"] = {

--- a/sdk/python/swarm/audit.py
+++ b/sdk/python/swarm/audit.py
@@ -171,6 +171,8 @@ def render_nhi_report(report: dict[str, Any]) -> str:
              f"isolation respected: {report['isolation_respected_count']}",
              f"would rely on it: {report['would_rely_on_it_count']}",
              "top failures: " + ("; ".join(report["top_failures"]) or "none")]
+    if report.get("assessment_phase_secs") is not None:
+        lines.append(f"assessment phase: {report['assessment_phase_secs']:.1f}s wall-clock")
     if report.get("mission_partial"):
         mp = report["mission_partial"]
         lines.append(f"mission partial: summaries {mp['summary_stored']} · lineage {mp['lineage_proved']} · facts {mp['facts_stored_total']}")

--- a/sdk/python/swarm/choreography.py
+++ b/sdk/python/swarm/choreography.py
@@ -60,12 +60,55 @@ class ScenarioResult:
     detail: str
 
 
-async def producer_consumer(swarm: Swarm) -> ScenarioResult:
-    """A -> B message lane; C must not see B's mail (isolation)."""
-    if len(swarm.agents) < 2:
-        return ScenarioResult("producer_consumer", ok=False, detail="need >= 2 agents")
-    a, b = swarm.agents[0], swarm.agents[1]
-    c = swarm.agents[2] if len(swarm.agents) > 2 else None
+def module_of(agent: SwarmAgent) -> str:
+    """The daemon (module) base URL this agent's client is bound to."""
+    return str(getattr(getattr(agent.client, "_client", None), "base_url", "") or "")
+
+
+def modules(swarm: Swarm) -> dict[str, list[SwarmAgent]]:
+    """Group the population by module, preserving spawn order inside each.
+
+    With ``SWARM_MODULES>1`` the launcher round-robins agents across several
+    INDEPENDENT data tiers (separate PG+AGE+pgvector stacks). Agent 0 and agent
+    1 then live on different tiers, so an A2A choreography built from
+    ``agents[0]`` and ``agents[1]`` asserts a cross-tier invariant that cannot
+    hold until node-to-node federation is wired (#3441).
+    """
+    grouped: dict[str, list[SwarmAgent]] = {}
+    for agent in swarm.agents:
+        grouped.setdefault(module_of(agent), []).append(agent)
+    return grouped
+
+
+def _slug(module: str | None) -> str:
+    """Short, title-safe module tag; empty for a single-module run."""
+    if not module:
+        return ""
+    return module.split("://", 1)[-1].strip("/").replace("/", "-") + "-"
+
+
+def _named(name: str, module: str | None) -> str:
+    """Scenario name, tagged with its module when the run is multi-module."""
+    return name if module is None else f"{name}@{module}"
+
+
+def _participants(swarm: Swarm, agents: list[SwarmAgent] | None) -> list[SwarmAgent]:
+    return swarm.agents if agents is None else agents
+
+
+async def producer_consumer(swarm: Swarm, agents: list[SwarmAgent] | None = None,
+                            module: str | None = None) -> ScenarioResult:
+    """A -> B message lane; C must not see B's mail (isolation).
+
+    ``agents`` defaults to the whole population; a multi-module run passes ONE
+    module's agents so the lane stays inside a single data tier.
+    """
+    name = _named("producer_consumer", module)
+    population = _participants(swarm, agents)
+    if len(population) < 2:
+        return ScenarioResult(name, ok=False, detail="need >= 2 agents")
+    a, b = population[0], population[1]
+    c = population[2] if len(population) > 2 else None
 
     subject = f"handoff-{a.identity.agent_id}"
     send = await dispatch(
@@ -91,26 +134,35 @@ async def producer_consumer(swarm: Swarm) -> ScenarioResult:
         c_isolated = not (c_inbox.ok and subject in json.dumps(c_inbox.result, default=str))
 
     ok = send.ok and b_saw and c_isolated
-    return ScenarioResult("producer_consumer", ok=ok,
+    return ScenarioResult(name, ok=ok,
                           detail=f"sent={send.ok} b_saw={b_saw} c_isolated={c_isolated}")
 
 
-async def consensus_quorum(swarm: Swarm) -> ScenarioResult:
-    """N agents attest the same fact into the shared ns; one consolidates."""
-    if len(swarm.agents) < 2:
-        return ScenarioResult("consensus_quorum", ok=False, detail="need >= 2 agents")
+async def consensus_quorum(swarm: Swarm, agents: list[SwarmAgent] | None = None,
+                           module: str | None = None) -> ScenarioResult:
+    """N agents attest the same fact into the shared ns; one consolidates.
+
+    The consolidator must be able to READ every vote, so all voters and the
+    consolidator have to sit on the same module (#3441): a vote stored on one
+    tier is "memory not found" to a consolidator on another.
+    """
+    name = _named("consensus_quorum", module)
+    population = _participants(swarm, agents)
+    if len(population) < 2:
+        return ScenarioResult(name, ok=False, detail="need >= 2 agents")
     fact = "the sky is blue"
     ids: list[str] = []
-    for ordinal, agent in enumerate(swarm.agents):
+    for ordinal, agent in enumerate(population):
         # Votes are "collective"-scoped: a private-scope row is readable only by
         # its author, so the consolidator could not read its peers' votes.
         out = await dispatch(agent.client, agent.identity, "store",
-                             {"title": f"consensus-vote-{_RUN}-{ordinal}", "content": fact,
+                             {"title": f"consensus-vote-{_RUN}-{_slug(module)}{ordinal}",
+                              "content": fact,
                               "namespace": swarm.shared_namespace, "scope": "collective"})
         swarm.coverage.record(out)
         if out.ok and isinstance(out.result, dict) and out.result.get("id"):
             ids.append(str(out.result["id"]))
-    consolidator = swarm.agents[0]
+    consolidator = population[0]
     # The daemon caps one consolidation at 100 sources ("cannot consolidate
     # more than 100 memories at once", measured at 128 agents). Fold the votes
     # in batches of <= 100, then fold the batch results into ONE consensus row.
@@ -122,7 +174,8 @@ async def consensus_quorum(swarm: Swarm) -> ScenarioResult:
         for start in range(0, len(level), batch_size):
             chunk = level[start:start + batch_size]
             cons = await dispatch(consolidator.client, consolidator.identity, "consolidate",
-                                  {"ids": chunk, "title": f"consensus-{_RUN}-{start // batch_size}-{len(level)}",
+                                  {"ids": chunk,
+                                   "title": f"consensus-{_RUN}-{_slug(module)}{start // batch_size}-{len(level)}",
                                    "namespace": swarm.shared_namespace})
             swarm.coverage.record(cons)
             if not cons.ok:
@@ -134,22 +187,25 @@ async def consensus_quorum(swarm: Swarm) -> ScenarioResult:
             break
         level = next_level
     ok = len(ids) >= 2 and cons is not None and cons.ok
-    return ScenarioResult("consensus_quorum", ok=ok,
-                          detail=f"votes={len(ids)} consolidated={cons.ok}")
+    return ScenarioResult(name, ok=ok,
+                          detail=f"votes={len(ids)} consolidated={cons is not None and cons.ok}")
 
 
-async def governance_approval(swarm: Swarm) -> ScenarioResult:
+async def governance_approval(swarm: Swarm, agents: list[SwarmAgent] | None = None,
+                              module: str | None = None) -> ScenarioResult:
     """Proposer requests; approver attests an approval decision + notifies back."""
-    if len(swarm.agents) < 2:
-        return ScenarioResult("governance_approval", ok=False, detail="need >= 2 agents")
-    proposer, approver = swarm.agents[0], swarm.agents[1]
+    name = _named("governance_approval", module)
+    population = _participants(swarm, agents)
+    if len(population) < 2:
+        return ScenarioResult(name, ok=False, detail="need >= 2 agents")
+    proposer, approver = population[0], population[1]
     ask = await dispatch(proposer.client, proposer.identity, "notify",
                          {"to_agent": approver.identity.agent_id,
                           "subject": "approve: publish-report", "body": "please approve"})
     swarm.coverage.record(ask)
     decision = await dispatch(
         approver.client, approver.identity, "store",
-        {"title": f"approval-decision-{_RUN}", "content": "APPROVED: publish-report",
+        {"title": f"approval-decision-{_RUN}-{_slug(module)}", "content": "APPROVED: publish-report",
          "namespace": swarm.shared_namespace, "scope": "collective",
          "tags": ["governance", "approval"]})
     swarm.coverage.record(decision)
@@ -158,7 +214,7 @@ async def governance_approval(swarm: Swarm) -> ScenarioResult:
                           "subject": "approved: publish-report", "body": "granted"})
     swarm.coverage.record(ack)
     ok = ask.ok and decision.ok and ack.ok
-    return ScenarioResult("governance_approval", ok=ok,
+    return ScenarioResult(name, ok=ok,
                           detail=f"asked={ask.ok} decided={decision.ok} acked={ack.ok}")
 
 
@@ -205,12 +261,15 @@ async def replay_guard(agent: SwarmAgent, namespace: str | None = None) -> Scena
     return ScenarioResult("replay_guard", ok=bool(first_id) and guarded, detail=detail)
 
 
-async def full_surface_sweep(swarm: Swarm) -> ScenarioResult:
+async def full_surface_sweep(swarm: Swarm, agents: list[SwarmAgent] | None = None,
+                             module: str | None = None) -> ScenarioResult:
     """Exercise the complete memory lifecycle through the dispatcher."""
-    if not swarm.agents:
-        return ScenarioResult("full_surface_sweep", ok=False, detail="need >= 1 agent")
-    agent = swarm.agents[0]
-    pattern = f"full-surface-{_RUN}"
+    name = _named("full_surface_sweep", module)
+    population = _participants(swarm, agents)
+    if not population:
+        return ScenarioResult(name, ok=False, detail="need >= 1 agent")
+    agent = population[0]
+    pattern = f"full-surface-{_RUN}-{_slug(module)}"
     completed: list[str] = []
 
     async def call(tool: str, args: dict[str, object]):
@@ -223,10 +282,10 @@ async def full_surface_sweep(swarm: Swarm) -> ScenarioResult:
     first = await call("store", {"title": f"{pattern}-source", "content": "source"})
     second = await call("store", {"title": f"{pattern}-target", "content": "target"})
     if not first.ok or not second.ok or not isinstance(first.result, dict) or not isinstance(second.result, dict):
-        return ScenarioResult("full_surface_sweep", False, f"stopped after {','.join(completed)}")
+        return ScenarioResult(name, False, f"stopped after {','.join(completed)}")
     source_id, target_id = first.result.get("id"), second.result.get("id")
     if not source_id or not target_id:
-        return ScenarioResult("full_surface_sweep", False, "store response missing id")
+        return ScenarioResult(name, False, "store response missing id")
 
     # Lineage edges point CHILD -> PARENT: the daemon's temporal lineage guard
     # (#3041) refuses an edge whose target is NEWER than its source, so the
@@ -253,9 +312,9 @@ async def full_surface_sweep(swarm: Swarm) -> ScenarioResult:
             if tool in swarm.coverage.documented_fail_closed and outcome.fail_closed:
                 completed.append(f"{tool}(fail-closed:documented)")
                 continue
-            return ScenarioResult("full_surface_sweep", False,
+            return ScenarioResult(name, False,
                                   f"{tool} failed after {','.join(completed)}: {outcome.summary}")
-    return ScenarioResult("full_surface_sweep", True, " -> ".join(completed))
+    return ScenarioResult(name, True, " -> ".join(completed))
 
 
 #: ~150k tokens at 4 chars/token — safely inside every model we run (GLM 200k, Grok 500k).
@@ -428,22 +487,99 @@ async def collect_assessments(swarm: Swarm) -> list[AgentAssessment]:
     return assessments
 
 
+#: Set to ``1`` once node-to-node federation is configured between the modules.
+#: Until then a cross-module handoff is EXPECTED not to arrive, and the audit
+#: says so explicitly instead of reporting a FAIL it cannot act on (#3441).
+FEDERATED_ENV = "SWARM_FEDERATED"
+
+
+def federation_expected(environ: dict[str, str] | None = None) -> bool:
+    """Whether the operator asserts f1<->f2 federation is wired for this run."""
+    env = os.environ if environ is None else environ
+    return (env.get(FEDERATED_ENV) or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+async def cross_module_handoff(swarm: Swarm, groups: dict[str, list[SwarmAgent]],
+                               *, federated: bool | None = None) -> ScenarioResult:
+    """A on module 1 notifies B on module 2 — the federation boundary probe.
+
+    This is an ASSERTION in both directions, never a rubber stamp:
+
+    * federation not configured (default): the notify must NOT reach the peer
+      module. It landing there would mean two supposedly independent data tiers
+      are leaking into each other — reported as a FAIL.
+    * ``SWARM_FEDERATED=1``: the operator asserts the tiers are federated, so
+      the message MUST arrive; not arriving is a FAIL.
+    """
+    name = "cross_module_handoff"
+    ordered = sorted(groups)
+    if len(ordered) < 2:
+        return ScenarioResult(name, ok=True, detail="single module: not applicable")
+    expect_federated = federation_expected() if federated is None else federated
+    a = groups[ordered[0]][0]
+    b = next((agent for agent in groups[ordered[1]] if agent is not a), None)
+    if b is None:
+        return ScenarioResult(name, ok=False, detail="need an agent on each module")
+
+    subject = f"cross-module-{_RUN}-{a.identity.agent_id}"
+    send = await dispatch(a.client, a.identity, "notify",
+                          {"to_agent": b.identity.agent_id, "subject": subject,
+                           "body": "cross-module handoff probe"})
+    swarm.coverage.record(send)
+    got = await dispatch(b.client, b.identity, "inbox", {"unread_only": True, "limit": 10})
+    swarm.coverage.record(got)
+    crossed = got.ok and subject in json.dumps(got.result, default=str)
+    where = f"{ordered[0]} -> {ordered[1]}"
+    if expect_federated:
+        return ScenarioResult(name, ok=bool(send.ok and crossed),
+                              detail=f"federated: {where} sent={send.ok} b_saw={crossed}")
+    if crossed:
+        return ScenarioResult(
+            name, ok=False,
+            detail=f"cross-module: {where} message CROSSED an unfederated boundary")
+    return ScenarioResult(name, ok=True,
+                          detail=f"cross-module: not federated (expected) [{where}]")
+
+
 async def run_all(swarm: Swarm) -> list[ScenarioResult]:
-    """Run every scenario in sequence against the population."""
-    results = [
-        await producer_consumer(swarm),
-        await consensus_quorum(swarm),
-        await governance_approval(swarm),
-        await full_surface_sweep(swarm),
-    ]
+    """Run every scenario in sequence against the population.
+
+    A single-module run is unchanged. With several modules every A2A scenario
+    runs ONCE PER MODULE over that module's own agents (#3441) — a producer and
+    consumer split across two unfederated tiers can never see each other's
+    inbox, and a consolidator can never read a vote stored on the other tier —
+    and the boundary itself is probed by :func:`cross_module_handoff`.
+    """
+    groups = modules(swarm)
+    if len(groups) <= 1:
+        results = [
+            await producer_consumer(swarm),
+            await consensus_quorum(swarm),
+            await governance_approval(swarm),
+            await full_surface_sweep(swarm),
+        ]
+    else:
+        results = []
+        for module in sorted(groups):
+            agents = groups[module]
+            results.append(await producer_consumer(swarm, agents, module))
+            results.append(await consensus_quorum(swarm, agents, module))
+            results.append(await governance_approval(swarm, agents, module))
+            results.append(await full_surface_sweep(swarm, agents, module))
+        results.append(await cross_module_handoff(swarm, groups))
     if swarm.agents:
         results.append(await replay_guard(swarm.agents[0]))
     return results
 
 
 __all__ = [
+    "FEDERATED_ENV",
     "ScenarioResult",
     "consensus_quorum",
+    "cross_module_handoff",
+    "federation_expected",
+    "module_of",
+    "modules",
     "governance_approval",
     "nhi_assessment",
     "negative_authorization_evidence",

--- a/sdk/python/swarm/choreography.py
+++ b/sdk/python/swarm/choreography.py
@@ -31,10 +31,14 @@ daemon response makes the scenario ``ok=False`` rather than passing silently.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import sys
+import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ai_memory.attestation import attestation_fields
@@ -42,6 +46,7 @@ from ai_memory.errors import AiMemoryError
 
 from swarm.openrouter import OpenRouterError
 from swarm.audit import AgentAssessment, parse_assessment
+from swarm.config import DEFAULT_ASSESS_CONCURRENCY
 from swarm.toolset import dispatch
 
 _RUN = uuid.uuid4().hex[:8]
@@ -372,7 +377,6 @@ async def nhi_assessment(
     if extra_path:
         try:
             # Intentionally verbatim: the auditor must see the original battery artifact.
-            from pathlib import Path
             evidence["extra_evidence_verbatim"] = Path(extra_path).read_text(encoding="utf-8")[:60000]
         except OSError as exc:
             evidence["extra_evidence_error"] = f"{type(exc).__name__}: {exc}"
@@ -460,31 +464,96 @@ _RUBRIC_PROMPT = """Return ONLY one JSON object with exactly these fields:
 Assess your just-completed mission from the supplied journal. Do not use tools."""
 
 
-async def collect_assessments(swarm: Swarm) -> list[AgentAssessment]:
-    """Run one strict no-tools rubric completion per agent and attest it."""
-    assessments: list[AgentAssessment] = []
-    for agent in swarm.agents:
-        messages = [{"role": "system", "content": _RUBRIC_PROMPT},
-                    {"role": "user", "content": _budget(json.dumps(
-                        {"agent_id": agent.identity.agent_id,
-                         "journal": [record.__dict__ for record in agent.journal]}, default=str), 200_000)}]
-        try:
-            raw = await agent.model.complete(messages=messages)
-            swarm.coverage.record_model_usage(agent.identity.agent_id, getattr(agent.model, "last_usage", None))
-            assessment = parse_assessment(agent.identity.agent_id, raw)
-        except OpenRouterError as exc:
-            assessment = parse_assessment(agent.identity.agent_id, "")
-            assessment = AgentAssessment(**{**assessment.__dict__,
-                                            "error": f"{type(exc).__name__}: {exc}"})
-        assessments.append(assessment)
-        stored = await dispatch(agent.client, agent.identity, "store", {
-            "title": f"nhi-audit-{agent.identity.agent_id}-{_RUN}",
-            "content": json.dumps(assessment.__dict__, sort_keys=True),
-            "namespace": swarm.shared_namespace, "scope": "collective",
-            "tags": ["nhi-audit"],
-        })
-        swarm.coverage.record(stored)
-    return assessments
+#: Streamed as each rubric lands, so a killed run keeps partial evidence.
+PARTIAL_ASSESSMENTS = "assessments.partial.jsonl"
+
+
+def _partial_path(journal_dir: str | Path | None) -> Path | None:
+    raw = journal_dir if journal_dir is not None else os.environ.get("SWARM_JOURNAL_DIR")
+    if not raw:
+        return None
+    destination = Path(raw)
+    destination.mkdir(parents=True, exist_ok=True)
+    return destination / PARTIAL_ASSESSMENTS
+
+
+def _append_partial(path: Path | None, assessment: AgentAssessment) -> None:
+    """Append one finished rubric. Fail-SOFT: streaming must never lose a run."""
+    if path is None:
+        return
+    try:
+        with path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(asdict(assessment), sort_keys=True, default=str) + "\n")
+    except OSError as exc:  # pragma: no cover - disk-full / permission
+        print(f"[assessments] partial stream unavailable: {type(exc).__name__}: {exc}",
+              file=sys.stderr)
+
+
+async def _assess_one(swarm: Swarm, agent: SwarmAgent) -> AgentAssessment:
+    """One agent's strict no-tools rubric completion, with ITS own usage."""
+    messages = [{"role": "system", "content": _RUBRIC_PROMPT},
+                {"role": "user", "content": _budget(json.dumps(
+                    {"agent_id": agent.identity.agent_id,
+                     "journal": [record.__dict__ for record in agent.journal]},
+                    default=str), 200_000)}]
+    try:
+        # Per-call usage, never the client-wide `last_usage`: several rubrics
+        # are in flight, so shared-attribute accounting would misbill agents.
+        raw, usage = await agent.model.complete_with_usage(messages=messages)
+        swarm.coverage.record_model_usage(agent.identity.agent_id, usage)
+        return parse_assessment(agent.identity.agent_id, raw)
+    except OpenRouterError as exc:
+        assessment = parse_assessment(agent.identity.agent_id, "")
+        return AgentAssessment(**{**assessment.__dict__,
+                                  "error": f"{type(exc).__name__}: {exc}"})
+
+
+async def collect_assessments(swarm: Swarm, *, concurrency: int | None = None,
+                              journal_dir: str | Path | None = None) -> list[AgentAssessment]:
+    """Run one strict no-tools rubric completion per agent and attest it.
+
+    Bounded-concurrent (#3346): at 256 agents and ~12 s per completion the
+    sequential loop left a ~50 minute tail after the mission had finished. A
+    semaphore of ``SWARM_ASSESS_CONCURRENCY`` (default
+    :data:`swarm.config.DEFAULT_ASSESS_CONCURRENCY`) keeps that paced — bounded,
+    never a synchronized 256-wide blast at the model or the daemon.
+
+    Everything else is unchanged: parsing stays strict, each agent's usage is
+    accounted to that agent, each rubric is attested by its own agent, and the
+    returned list is in agent order — identical to the sequential result. Each
+    rubric is also appended to ``assessments.partial.jsonl`` as it lands, so a
+    killed run keeps the evidence it had already paid for.
+    """
+    agents = list(swarm.agents)
+    if concurrency is None:
+        concurrency = getattr(swarm.config, "assess_concurrency", DEFAULT_ASSESS_CONCURRENCY)
+    semaphore = asyncio.Semaphore(max(1, int(concurrency)))
+    partial = _partial_path(journal_dir)
+    assessments: list[AgentAssessment | None] = [None] * len(agents)
+    started = time.perf_counter()
+
+    async def _one(index: int, agent: SwarmAgent) -> None:
+        async with semaphore:
+            try:
+                assessment = await _assess_one(swarm, agent)
+            except Exception as exc:  # noqa: BLE001 - one agent never aborts the fleet
+                assessment = AgentAssessment(
+                    agent.identity.agent_id, None, None, [], None, None, "",
+                    assessment_invalid=True, error=f"{type(exc).__name__}: {exc}")
+            assessments[index] = assessment
+            _append_partial(partial, assessment)
+            stored = await dispatch(agent.client, agent.identity, "store", {
+                "title": f"nhi-audit-{agent.identity.agent_id}-{_RUN}",
+                "content": json.dumps(asdict(assessment), sort_keys=True),
+                "namespace": swarm.shared_namespace, "scope": "collective",
+                "tags": ["nhi-audit"],
+            })
+            swarm.coverage.record(stored)
+
+    await asyncio.gather(*(_one(index, agent) for index, agent in enumerate(agents)))
+    swarm.coverage.record_phase("assessments", time.perf_counter() - started)
+    # Order is by agent, not by completion, so the artifact is reproducible.
+    return [item for item in assessments if item is not None]
 
 
 #: Set to ``1`` once node-to-node federation is configured between the modules.
@@ -574,6 +643,7 @@ async def run_all(swarm: Swarm) -> list[ScenarioResult]:
 
 __all__ = [
     "FEDERATED_ENV",
+    "PARTIAL_ASSESSMENTS",
     "ScenarioResult",
     "consensus_quorum",
     "cross_module_handoff",

--- a/sdk/python/swarm/config.py
+++ b/sdk/python/swarm/config.py
@@ -30,6 +30,9 @@ OPENROUTER_MODEL_SLUG = "z-ai/glm-5.3-flash"
 
 DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 DEFAULT_DAEMON_BASE_URL = "http://localhost:9077"
+#: Default bound on concurrent per-agent assessment completions (#3346).
+DEFAULT_ASSESS_CONCURRENCY = 8
+
 DEFAULT_MISSION = (
     "Gather three useful facts as memories; link them with derives_from and consolidate them; "
     "write exactly one mission-summary-<agent> memory in the shared namespace citing the "
@@ -94,6 +97,10 @@ class SwarmConfig:
     api_key: str | None = None
     admin_agent_id: str = "ai:hive-loadgen-f2"
     mission: str = DEFAULT_MISSION
+    #: How many per-agent rubric completions may be in flight at once. Bounded
+    #: on purpose: 1 leaves a ~50 min tail at 256 agents (#3346), unbounded
+    #: would be a 256-wide synchronized blast at the model endpoint.
+    assess_concurrency: int = DEFAULT_ASSESS_CONCURRENCY
 
     def __post_init__(self) -> None:
         if not self.base_urls:
@@ -102,6 +109,9 @@ class SwarmConfig:
             raise ConfigError(f"n_agents must be >= 1, got {self.n_agents}")
         if self.max_steps < 1:
             raise ConfigError(f"max_steps must be >= 1, got {self.max_steps}")
+        if self.assess_concurrency < 1:
+            raise ConfigError(
+                f"assess_concurrency must be >= 1, got {self.assess_concurrency}")
         if self.model_slug != OPENROUTER_MODEL_SLUG and not self.model_override_reason:
             raise ConfigError(
                 f"model {self.model_slug!r} is not the pinned acceptance model "
@@ -135,6 +145,7 @@ class SwarmConfig:
         ``SWARM_CA_CERT``            hive CA certificate path
         ``SWARM_API_KEY``            per-node HTTP request credential
         ``SWARM_MODEL_SLUG``         OpenRouter model override (audit-only use)
+        ``SWARM_ASSESS_CONCURRENCY`` bound on concurrent rubric completions
         ``SWARM_MODEL_OVERRIDE_REASON`` REQUIRED with an override; recorded
         ==========================  ===================================
         """
@@ -166,6 +177,8 @@ class SwarmConfig:
             api_key=env.get("SWARM_API_KEY") or None,
             admin_agent_id=env.get("SWARM_ADMIN_AGENT_ID", "ai:hive-loadgen-f2"),
             mission=env.get("SWARM_MISSION", DEFAULT_MISSION),
+            assess_concurrency=_int_env(
+                env, "SWARM_ASSESS_CONCURRENCY", DEFAULT_ASSESS_CONCURRENCY),
             model_slug=env.get("SWARM_MODEL_SLUG") or OPENROUTER_MODEL_SLUG,
             model_override_reason=env.get("SWARM_MODEL_OVERRIDE_REASON") or None,
         )

--- a/sdk/python/swarm/coverage.py
+++ b/sdk/python/swarm/coverage.py
@@ -60,6 +60,9 @@ class CoverageTracker:
     documented_fail_closed: set[str] = field(default_factory=set)
     model_usage: dict[str, dict[str, float | int]] = field(default_factory=dict)
     model_latencies_ms: list[float] = field(default_factory=list)
+    #: Wall-clock seconds per named run phase (e.g. "assessments"), so a long
+    #: tail after the mission is visible in the artifacts, not just in a log.
+    phase_secs: dict[str, float] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if not self.tools:
@@ -92,6 +95,10 @@ class CoverageTracker:
         safe default.
         """
         self.documented_fail_closed.update(names)
+
+    def record_phase(self, name: str, seconds: float) -> None:
+        """Record (accumulate) the wall-clock a named run phase took."""
+        self.phase_secs[name] = round(self.phase_secs.get(name, 0.0) + float(seconds), 3)
 
     def record_model_usage(
         self, agent_id: str, raw_usage: Any, latency_ms: float | None = None

--- a/sdk/python/swarm/openrouter.py
+++ b/sdk/python/swarm/openrouter.py
@@ -144,18 +144,41 @@ class OpenRouterClient:
         This is intentionally separate from :meth:`decide`: an assessment
         must describe the evidence it was given, never take another action.
         Empty or non-text content is malformed and therefore fails closed.
+
+        Note: :attr:`last_usage` is per-CLIENT and therefore only meaningful
+        while completions are issued one at a time. Concurrent callers must use
+        :meth:`complete_with_usage`, which returns the usage of their own call.
         """
-        _body, message = await self._chat({
+        content, _usage = await self.complete_with_usage(
+            messages=messages, temperature=temperature)
+        return content
+
+    async def complete_with_usage(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        temperature: float = 0.1,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """:meth:`complete`, returning THIS call's usage block alongside it.
+
+        Attributing usage through the shared :attr:`last_usage` attribute is a
+        race as soon as several completions are in flight (#3346): whichever
+        response landed last would be billed to every agent. The usage travels
+        with the response instead, so per-agent accounting stays exact at any
+        concurrency.
+        """
+        body, message = await self._chat({
             "model": self._model,
             "messages": messages,
             "temperature": temperature,
             "usage": {"include": True},
         })
         content = message.get("content")
-        self.last_usage = _body.get("usage") if isinstance(_body, dict) else None
+        usage = body.get("usage") if isinstance(body, dict) else None
+        self.last_usage = usage
         if not isinstance(content, str) or not content.strip():
             raise OpenRouterError("malformed OpenRouter response: missing assessment content")
-        return content.strip()
+        return content.strip(), usage if isinstance(usage, dict) else None
 
     async def _chat(
         self, payload: dict[str, Any]

--- a/sdk/python/swarm/tests/test_assess_concurrency.py
+++ b/sdk/python/swarm/tests/test_assess_concurrency.py
@@ -1,0 +1,224 @@
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+"""#3346 — per-agent rubric assessments run with a bounded concurrency.
+
+Offline: the model is a fake with a fixed latency, the daemon an
+``httpx.MockTransport``. Proves the phase is no longer serialised, that the
+bound is respected, that per-agent usage stays exact under concurrency, and
+that the results are identical (and identically ordered) to the sequential run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from ai_memory import AsyncAiMemoryClient
+from ai_memory.attestation import AgentSigningKey
+from swarm.agent import SwarmAgent, StepRecord
+from swarm.choreography import PARTIAL_ASSESSMENTS, collect_assessments
+from swarm.config import DEFAULT_ASSESS_CONCURRENCY, ConfigError, SwarmConfig
+from swarm.coverage import CoverageTracker
+from swarm.openrouter import OpenRouterError
+from swarm.toolset import AgentIdentity
+
+
+class _LatentModel:
+    """A model whose completion takes ``latency`` seconds and bills per call."""
+
+    def __init__(self, latency: float = 0.1, *, fail_for: set[str] | None = None) -> None:
+        self.latency = latency
+        self.fail_for = fail_for or set()
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self.calls = 0
+
+    async def complete_with_usage(self, *, messages, temperature: float = 0.1):
+        self.calls += 1
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        try:
+            await asyncio.sleep(self.latency)
+            agent_id = json.loads(messages[1]["content"])["agent_id"]
+            if agent_id in self.fail_for:
+                raise OpenRouterError("induced upstream failure")
+            ordinal = int(agent_id.rsplit("-", 1)[-1])
+            rubric = {
+                "recall_usefulness": 1 + ordinal % 5,
+                "latency_acceptable": True,
+                "failures_encountered": [],
+                "isolation_respected": True,
+                "would_rely_on_it": True,
+                "free_text": f"agent {ordinal} reporting",
+            }
+            # Distinct token counts per agent: misattribution is then visible.
+            usage = {"prompt_tokens": 10 + ordinal, "completion_tokens": 1,
+                     "total_tokens": 11 + ordinal, "cost": 0.001}
+            return json.dumps(rubric), usage
+        finally:
+            self.in_flight -= 1
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _mock_daemon() -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/memories" and request.method == "POST":
+            return httpx.Response(201, json={"id": "mem-1", "version": 1})
+        return httpx.Response(200, json={"ok": True})
+
+    return httpx.MockTransport(handler)
+
+
+def _swarm(model: _LatentModel, n_agents: int, *, concurrency: int) -> SimpleNamespace:
+    config = SwarmConfig(base_urls=["http://mock"], n_agents=n_agents, max_steps=1,
+                         assess_concurrency=concurrency)
+    agents = []
+    for ordinal in range(n_agents):
+        agent_id = f"ai:swarm-{ordinal}"
+        client = AsyncAiMemoryClient(base_url="http://mock", agent_id=agent_id)
+        client._client = httpx.AsyncClient(  # noqa: SLF001 - offline transport injection
+            base_url="http://mock", transport=_mock_daemon())
+        identity = AgentIdentity(agent_id=agent_id, signing_key=AgentSigningKey.generate(),
+                                 namespace=f"swarm-{ordinal:03d}",
+                                 allowed_namespaces={f"swarm-{ordinal:03d}", "swarm-shared"})
+        agent = SwarmAgent(identity=identity, client=client,
+                           model=model,  # type: ignore[arg-type]
+                           config=config, coverage=CoverageTracker())
+        agent.journal.append(StepRecord(1, "recall[ok]", ["store"], ["store -> ok"]))
+        agents.append(agent)
+    return SimpleNamespace(agents=agents, coverage=CoverageTracker(), config=config,
+                           shared_namespace="swarm-shared")
+
+
+async def _aclose(swarm: SimpleNamespace) -> None:
+    for agent in swarm.agents:
+        await agent.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bounded_concurrency_collapses_the_assessment_tail() -> None:
+    model = _LatentModel(latency=0.1)
+    swarm = _swarm(model, 64, concurrency=16)
+    started = time.perf_counter()
+    try:
+        assessments = await collect_assessments(swarm)
+    finally:
+        await _aclose(swarm)
+    elapsed = time.perf_counter() - started
+    # Sequential would be 64 x 100ms = 6.4 s; the issue's bar is < 2 s at 16.
+    assert elapsed < 2.0, elapsed
+    assert len(assessments) == 64
+    assert model.max_in_flight <= 16
+    # ... and the bound is actually USED (never a 64-wide blast, never serial).
+    assert model.max_in_flight > 1
+    assert swarm.coverage.phase_secs["assessments"] == pytest.approx(elapsed, abs=0.5)
+
+
+@pytest.mark.asyncio
+async def test_results_are_identical_and_ordered_like_the_sequential_run() -> None:
+    sequential_swarm = _swarm(_LatentModel(latency=0.0), 12, concurrency=1)
+    try:
+        sequential = await collect_assessments(sequential_swarm)
+    finally:
+        await _aclose(sequential_swarm)
+    concurrent_swarm = _swarm(_LatentModel(latency=0.01), 12, concurrency=8)
+    try:
+        concurrent = await collect_assessments(concurrent_swarm)
+    finally:
+        await _aclose(concurrent_swarm)
+    assert [a.agent_id for a in concurrent] == [f"ai:swarm-{i}" for i in range(12)]
+    assert [a.__dict__ for a in concurrent] == [a.__dict__ for a in sequential]
+
+
+@pytest.mark.asyncio
+async def test_per_agent_usage_accounting_survives_concurrency() -> None:
+    """The `last_usage` race: whichever response landed last would bill everyone."""
+    model = _LatentModel(latency=0.02)
+    swarm = _swarm(model, 16, concurrency=8)
+    try:
+        await collect_assessments(swarm)
+    finally:
+        await _aclose(swarm)
+    usage = swarm.coverage.model_usage
+    assert len(usage) == 16
+    for ordinal in range(16):
+        totals = usage[f"ai:swarm-{ordinal}"]
+        assert totals["requests"] == 1
+        assert totals["prompt_tokens"] == 10 + ordinal
+        assert totals["total_tokens"] == 11 + ordinal
+
+
+@pytest.mark.asyncio
+async def test_one_failing_agent_fails_closed_without_losing_the_fleet() -> None:
+    model = _LatentModel(latency=0.0, fail_for={"ai:swarm-3"})
+    swarm = _swarm(model, 6, concurrency=4)
+    try:
+        assessments = await collect_assessments(swarm)
+    finally:
+        await _aclose(swarm)
+    assert len(assessments) == 6
+    failed = [a for a in assessments if a.assessment_invalid]
+    assert [a.agent_id for a in failed] == ["ai:swarm-3"]
+    assert "OpenRouterError" in (failed[0].error or "")
+    # Every agent still attested its rubric (including the failed one).
+    assert swarm.coverage.tools["store"].successes == 6
+
+
+@pytest.mark.asyncio
+async def test_each_rubric_is_streamed_as_it_lands(tmp_path) -> None:
+    model = _LatentModel(latency=0.01)
+    swarm = _swarm(model, 8, concurrency=4)
+    try:
+        assessments = await collect_assessments(swarm, journal_dir=tmp_path)
+    finally:
+        await _aclose(swarm)
+    streamed = [json.loads(line) for line in
+                (tmp_path / PARTIAL_ASSESSMENTS).read_text(encoding="utf-8").splitlines()]
+    # A killed run keeps every rubric it had already paid for, in any order.
+    assert len(streamed) == len(assessments) == 8
+    assert {item["agent_id"] for item in streamed} == {a.agent_id for a in assessments}
+    assert {item["free_text"] for item in streamed} == {a.free_text for a in assessments}
+
+
+def test_concurrency_is_configurable_and_fails_closed_on_nonsense() -> None:
+    assert SwarmConfig.from_env({}).assess_concurrency == DEFAULT_ASSESS_CONCURRENCY == 8
+    assert SwarmConfig.from_env({"SWARM_ASSESS_CONCURRENCY": "32"}).assess_concurrency == 32
+    with pytest.raises(ConfigError, match="SWARM_ASSESS_CONCURRENCY"):
+        SwarmConfig.from_env({"SWARM_ASSESS_CONCURRENCY": "many"})
+    with pytest.raises(ConfigError, match="assess_concurrency must be >= 1"):
+        SwarmConfig(base_urls=["http://mock"], assess_concurrency=0)
+
+
+@pytest.mark.asyncio
+async def test_complete_with_usage_returns_this_calls_usage() -> None:
+    """The real client: usage travels with the response, not on the client."""
+    from swarm.openrouter import OpenRouterClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        tag = payload["messages"][0]["content"]
+        return httpx.Response(200, json={
+            "choices": [{"message": {"content": f"reply-{tag}"}}],
+            "usage": {"prompt_tokens": int(tag), "completion_tokens": 1,
+                      "total_tokens": int(tag) + 1, "cost": 0.5},
+        })
+
+    client = OpenRouterClient(api_key="test", model_slug="test-model", base_url="http://mock")
+    await client._client.aclose()  # noqa: SLF001
+    client._client = httpx.AsyncClient(  # noqa: SLF001
+        base_url="http://mock", transport=httpx.MockTransport(handler))
+    try:
+        results = await asyncio.gather(*(
+            client.complete_with_usage(messages=[{"role": "system", "content": str(n)}])
+            for n in (7, 11, 13)))
+    finally:
+        await client.aclose()
+    assert [content for content, _usage in results] == ["reply-7", "reply-11", "reply-13"]
+    assert [usage["prompt_tokens"] for _content, usage in results] == [7, 11, 13]

--- a/sdk/python/swarm/tests/test_module_local_choreography.py
+++ b/sdk/python/swarm/tests/test_module_local_choreography.py
@@ -1,0 +1,269 @@
+# Copyright 2026 AlphaOne LLC
+# SPDX-License-Identifier: Apache-2.0
+"""#3441 — choreographies must stay inside one module (data tier).
+
+Two fake modules, each an ``httpx.MockTransport`` with its OWN inbox and memory
+store and NO federation between them — exactly the shape of the 2-module run
+where ``producer_consumer`` and ``consensus_quorum`` failed because agent 0 sat
+on f2 and agent 1 on f1. Offline: no daemon, no OpenRouter.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from ai_memory import AsyncAiMemoryClient
+from ai_memory.attestation import AgentSigningKey
+from swarm.agent import SwarmAgent
+from swarm.choreography import (consensus_quorum, cross_module_handoff, federation_expected,
+                                module_of, modules, producer_consumer, run_all)
+from swarm.config import SwarmConfig
+from swarm.coverage import CoverageTracker
+from swarm.toolset import AgentIdentity
+from swarm.tests.test_agent_loop_mock import _FakeModel
+from swarm.openrouter import Decision
+
+
+class _Module:
+    """One INDEPENDENT data tier: its own inboxes, memories, and request log."""
+
+    def __init__(self, base_url: str, *, leaks_to: _Module | None = None) -> None:
+        self.base_url = base_url
+        self.inboxes: dict[str, list[dict[str, str]]] = {}
+        self.requests: list[httpx.Request] = []
+        self.rows = 0
+        self.written: dict[tuple[object, object, object], str] = {}
+        #: Only set by the leak test: simulates a boundary that is NOT airtight.
+        self.leaks_to = leaks_to
+
+    def deliver(self, target: str, title: str) -> None:
+        self.inboxes.setdefault(target, []).append({"title": title, "payload": "x"})
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        path, method = request.url.path, request.method
+        agent = request.headers.get("X-Agent-Id", "")
+        if path == "/api/v1/notify":
+            body = json.loads(request.content)
+            self.deliver(body["target_agent_id"], body["title"])
+            if self.leaks_to is not None:
+                self.leaks_to.deliver(body["target_agent_id"], body["title"])
+            return httpx.Response(200, json={"delivered": True})
+        if path == "/api/v1/inbox":
+            target = request.url.params.get("agent_id") or agent
+            return httpx.Response(200, json={"messages": self.inboxes.get(target, [])})
+        if path == "/api/v1/memories" and method == "POST":
+            body = json.loads(request.content)
+            # Replay-guard: the SAME signed envelope dedups to the same row,
+            # never a second durable write (what `replay_guard` asserts).
+            key = (body.get("title"), body.get("signature"), body.get("created_at"))
+            if body.get("signature") and key in self.written:
+                return httpx.Response(200, json={"id": self.written[key], "version": 1})
+            self.rows += 1
+            memory_id = f"{self.base_url}-mem-{self.rows}"
+            if body.get("signature"):
+                self.written[key] = memory_id
+            return httpx.Response(201, json={"id": memory_id, "version": 1})
+        if path == "/api/v1/consolidate":
+            return httpx.Response(201, json={"id": f"{self.base_url}-con"})
+        if path.startswith("/api/v1/memories/") and method == "GET" \
+                and not path.endswith("/lineage"):
+            return httpx.Response(200, json={"memory": {
+                "id": path.rsplit("/", 1)[-1], "tier": "mid", "namespace": "swarm-000",
+                "title": "t", "content": "c", "tags": [], "priority": 5, "confidence": 1.0,
+                "source": "api", "access_count": 0, "created_at": "2026-09-01T00:00:00Z",
+                "updated_at": "2026-09-01T00:00:00Z", "metadata": {}}, "links": []})
+        if path == "/api/v1/recall":
+            return httpx.Response(200, json={"count": 0, "memories": []})
+        if path == "/api/v1/search":
+            return httpx.Response(200, json={"results": [], "count": 0, "query": ""})
+        return httpx.Response(200, json={"ok": True})
+
+
+def _agent_on(module: _Module, ordinal: int) -> SwarmAgent:
+    """One agent bound to ``module`` — its client speaks ONLY to that tier."""
+    agent_id = f"ai:swarm-{ordinal:03d}"
+    namespace = f"swarm-{ordinal:03d}"
+    config = SwarmConfig(base_urls=[module.base_url], n_agents=1, max_steps=1)
+    client = AsyncAiMemoryClient(base_url=module.base_url, agent_id=agent_id)
+    client._client = httpx.AsyncClient(  # noqa: SLF001 - offline transport injection
+        base_url=module.base_url, transport=httpx.MockTransport(module.handle),
+        headers={"X-Agent-Id": agent_id})
+    identity = AgentIdentity(
+        agent_id=agent_id, signing_key=AgentSigningKey.generate(),
+        namespace=namespace, allowed_namespaces={namespace, "swarm-shared"})
+    return SwarmAgent(identity=identity, client=client,
+                      model=_FakeModel(Decision(None, [], {})),  # type: ignore[arg-type]
+                      config=config, coverage=CoverageTracker())
+
+
+def _two_module_swarm(*, leaky: bool = False) -> tuple[SimpleNamespace, _Module, _Module]:
+    """Agents round-robined across two modules, exactly as the launcher does."""
+    second = _Module("http://mod-b")
+    first = _Module("http://mod-a", leaks_to=second if leaky else None)
+    agents = [_agent_on(first if ordinal % 2 == 0 else second, ordinal)
+              for ordinal in range(6)]
+    swarm = SimpleNamespace(agents=agents, coverage=CoverageTracker(),
+                            shared_namespace="swarm-shared")
+    return swarm, first, second
+
+
+async def _aclose(swarm: SimpleNamespace) -> None:
+    for agent in swarm.agents:
+        await agent.aclose()
+
+
+def test_modules_groups_agents_by_client_base_url() -> None:
+    swarm, first, second = _two_module_swarm()
+    grouped = modules(swarm)
+    assert sorted(grouped) == ["http://mod-a", "http://mod-b"]
+    assert [module_of(agent) for agent in grouped["http://mod-a"]] == ["http://mod-a"] * 3
+    # Round-robin really does split agent 0 from agent 1 (the #3441 failure).
+    assert module_of(swarm.agents[0]) != module_of(swarm.agents[1])
+
+
+@pytest.mark.asyncio
+async def test_producer_consumer_is_module_local() -> None:
+    swarm, first, second = _two_module_swarm()
+    try:
+        agents = modules(swarm)["http://mod-a"]
+        result = await producer_consumer(swarm, agents, "http://mod-a")
+    finally:
+        await _aclose(swarm)
+    assert result.ok, result.detail
+    assert result.name == "producer_consumer@http://mod-a"
+    assert "b_saw=True" in result.detail and "c_isolated=True" in result.detail
+    # Every call stayed on one tier; the other module was never touched.
+    assert second.requests == []
+
+
+@pytest.mark.asyncio
+async def test_producer_consumer_across_modules_would_fail() -> None:
+    """The behaviour this issue is about, kept as the negative control."""
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        # agents[0] and agents[1] are on DIFFERENT modules (the old default).
+        result = await producer_consumer(swarm, swarm.agents[:3])
+    finally:
+        await _aclose(swarm)
+    assert not result.ok
+    assert "b_saw=False" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_consensus_quorum_votes_and_consolidates_on_one_module() -> None:
+    swarm, first, second = _two_module_swarm()
+    try:
+        result = await consensus_quorum(swarm, modules(swarm)["http://mod-b"], "http://mod-b")
+    finally:
+        await _aclose(swarm)
+    assert result.ok, result.detail
+    assert result.name == "consensus_quorum@http://mod-b"
+    assert "votes=3" in result.detail
+    # The consolidator only ever saw ids minted by its own module.
+    assert first.requests == []
+
+
+@pytest.mark.asyncio
+async def test_run_all_runs_every_scenario_once_per_module() -> None:
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        results = await run_all(swarm)
+    finally:
+        await _aclose(swarm)
+    names = [result.name for result in results]
+    for scenario in ("producer_consumer", "consensus_quorum", "governance_approval",
+                     "full_surface_sweep"):
+        assert f"{scenario}@http://mod-a" in names
+        assert f"{scenario}@http://mod-b" in names
+        # No un-tagged (cross-module) variant is run any more.
+        assert scenario not in names
+    assert "cross_module_handoff" in names
+    assert "replay_guard" in names
+    failed = [(r.name, r.detail) for r in results if not r.ok]
+    assert failed == [], failed
+
+
+@pytest.mark.asyncio
+async def test_single_module_run_is_unchanged() -> None:
+    only = _Module("http://mod-a")
+    agents = [_agent_on(only, ordinal) for ordinal in range(3)]
+    swarm = SimpleNamespace(agents=agents, coverage=CoverageTracker(),
+                            shared_namespace="swarm-shared")
+    try:
+        results = await run_all(swarm)
+    finally:
+        await _aclose(swarm)
+    names = [result.name for result in results]
+    assert names == ["producer_consumer", "consensus_quorum", "governance_approval",
+                     "full_surface_sweep", "replay_guard"]
+    assert all(result.ok for result in results), [r.detail for r in results if not r.ok]
+
+
+@pytest.mark.asyncio
+async def test_cross_module_handoff_reports_not_federated_rather_than_fail() -> None:
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        result = await cross_module_handoff(swarm, modules(swarm), federated=False)
+    finally:
+        await _aclose(swarm)
+    assert result.ok
+    assert result.detail.startswith("cross-module: not federated (expected)")
+
+
+@pytest.mark.asyncio
+async def test_cross_module_handoff_fails_when_an_unfederated_boundary_leaks() -> None:
+    """Not a rubber stamp: a message that DOES cross is a data-isolation failure."""
+    swarm, _first, _second = _two_module_swarm(leaky=True)
+    try:
+        result = await cross_module_handoff(swarm, modules(swarm), federated=False)
+    finally:
+        await _aclose(swarm)
+    assert not result.ok
+    assert "CROSSED an unfederated boundary" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_cross_module_handoff_asserts_delivery_once_federated() -> None:
+    # SWARM_FEDERATED=1 flips the probe into a real delivery assertion.
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        unfederated = await cross_module_handoff(swarm, modules(swarm), federated=True)
+    finally:
+        await _aclose(swarm)
+    assert not unfederated.ok
+    assert "b_saw=False" in unfederated.detail
+
+    federated_swarm, _a, _b = _two_module_swarm(leaky=True)
+    try:
+        delivered = await cross_module_handoff(federated_swarm, modules(federated_swarm),
+                                               federated=True)
+    finally:
+        await _aclose(federated_swarm)
+    assert delivered.ok
+    assert "b_saw=True" in delivered.detail
+
+
+def test_federation_flag_is_opt_in_and_explicit() -> None:
+    assert federation_expected({}) is False
+    assert federation_expected({"SWARM_FEDERATED": "0"}) is False
+    assert federation_expected({"SWARM_FEDERATED": ""}) is False
+    assert federation_expected({"SWARM_FEDERATED": "1"}) is True
+    assert federation_expected({"SWARM_FEDERATED": "true"}) is True
+
+
+@pytest.mark.asyncio
+async def test_cross_module_handoff_is_not_applicable_on_one_module() -> None:
+    only = _Module("http://mod-a")
+    agents = [_agent_on(only, ordinal) for ordinal in range(2)]
+    swarm = SimpleNamespace(agents=agents, coverage=CoverageTracker(),
+                            shared_namespace="swarm-shared")
+    try:
+        result = await cross_module_handoff(swarm, modules(swarm), federated=False)
+    finally:
+        await _aclose(swarm)
+    assert result.ok and result.detail == "single module: not applicable"

--- a/sdk/python/swarm/tests/test_module_local_choreography.py
+++ b/sdk/python/swarm/tests/test_module_local_choreography.py
@@ -37,6 +37,8 @@ class _Module:
         self.requests: list[httpx.Request] = []
         self.rows = 0
         self.written: dict[tuple[object, object, object], str] = {}
+        #: Ids this tier actually minted; anything else is "memory not found".
+        self.minted: set[str] = set()
         #: Only set by the leak test: simulates a boundary that is NOT airtight.
         self.leaks_to = leaks_to
 
@@ -65,10 +67,17 @@ class _Module:
                 return httpx.Response(200, json={"id": self.written[key], "version": 1})
             self.rows += 1
             memory_id = f"{self.base_url}-mem-{self.rows}"
+            self.minted.add(memory_id)
             if body.get("signature"):
                 self.written[key] = memory_id
             return httpx.Response(201, json={"id": memory_id, "version": 1})
         if path == "/api/v1/consolidate":
+            # A tier can only fold ids IT stored: a vote written to the other
+            # module is "memory not found" here, exactly as the daemon reports.
+            unknown = [i for i in json.loads(request.content).get("ids", [])
+                       if i not in self.minted]
+            if unknown:
+                return httpx.Response(404, json={"error": f"memory not found: {unknown[0]}"})
             return httpx.Response(201, json={"id": f"{self.base_url}-con"})
         if path.startswith("/api/v1/memories/") and method == "GET" \
                 and not path.endswith("/lineage"):
@@ -152,6 +161,18 @@ async def test_producer_consumer_across_modules_would_fail() -> None:
         await _aclose(swarm)
     assert not result.ok
     assert "b_saw=False" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_consensus_quorum_across_modules_cannot_read_its_own_votes() -> None:
+    """The observed failure: votes=256 consolidated=False ("memory not found")."""
+    swarm, _first, _second = _two_module_swarm()
+    try:
+        result = await consensus_quorum(swarm, swarm.agents)
+    finally:
+        await _aclose(swarm)
+    assert not result.ok
+    assert "consolidated=False" in result.detail
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #3346

## What
`collect_assessments()` awaited one no-tools completion per agent in a for-loop, so a 256-agent run spent ~50 minutes in the assessment phase after the mission and choreographies had finished (0-4 agents visible on the fabric, call log stalled at ~11.4k entries).

The completions now run under an `asyncio.Semaphore` sized by `SWARM_ASSESS_CONCURRENCY` (default **8**, validated `>= 1`). Bounded in *both* directions on purpose: 1 is the 50-minute tail, unbounded would be a 256-wide synchronized blast at the model endpoint and at the daemon behind the attesting store.

Concurrency must not cost accounting accuracy: usage no longer comes from the client-wide `OpenRouterClient.last_usage` (whichever response landed last would have been billed to every agent). `complete_with_usage()` returns the usage of its own call. Results are collected by agent index, so the artifact is identical to the sequential run, and one agent's failure still fails closed to an invalid rubric without aborting the fleet.

Each rubric is appended to `assessments.partial.jsonl` as it lands (a killed run keeps the evidence it already paid for), and the assessment phase's wall-clock is recorded (`CoverageTracker.record_phase`) and reported in the NHI AUDIT block and `usage.json`.

Preflight is deliberately left sequential: it is daemon-local, fast, and already paced — concurrency there would trade a thundering herd for nothing.

## Repro (offline, fake model at 100 ms)
```
BEFORE  64 agents x 100 ms: assessment phase 6.53s  max_in_flight=1   per-agent usage exact=True  phase_secs=n/a
AFTER   64 agents x 100 ms: assessment phase 0.45s  max_in_flight=16  per-agent usage exact=True  phase_secs={'assessments': 0.452}
```
(14.5x; at the real 256 x ~12 s that is ~51 min -> ~6.4 min at the default 8.)

## Tests
`sdk/python/swarm/tests/test_assess_concurrency.py` — 7 offline tests: the issue's own bar (64 agents, 100 ms, concurrency 16 -> phase < 2 s) with the bound proven both respected and used; results identical and identically ordered to a sequential run; per-agent usage exact under concurrency (16 agents with distinct token counts); one agent failing closed without losing the fleet; the streamed partial file; config default/override/fail-closed on nonsense; and the real `OpenRouterClient` returning each concurrent call's own usage.

`cd sdk/python && python -m pytest . -q` -> **106 passed, 4 skipped** (99 before). `python -m ruff check swarm` clean. `SWARM_ASSESS_CONCURRENCY` + the new artifact documented in `swarm/README.md`.

Test-only harness (`sdk/python/swarm`); nothing under `src/` or the daemon changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y69UfdxKNcRw7tftCAiNwi
